### PR TITLE
show help when iapp is invoked without matching subcommand

### DIFF
--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -145,5 +145,7 @@ yargsInstance
   .help()
   .alias('help', 'h')
   .alias('version', 'v')
+  .strict() // show help if iapp is invoked with an invalid subcommand
+  .demandCommand(1, 'Missing subcommand') // show help if iapp is invoked without subcommand is invoked
   .wrap(yargsInstance.terminalWidth()) // use full terminal size rather than default 80
   .parse();


### PR DESCRIPTION


| command | before | after |
| --- | --- | --- |
| `iapp` | ![image](https://github.com/user-attachments/assets/1ef1c045-2cb9-4668-8115-ac14b716fb56) | ![image](https://github.com/user-attachments/assets/55a431f2-4afe-48a0-a932-9d20372844dc) |
| `iapp foo` | ![image](https://github.com/user-attachments/assets/5a08401c-f789-420e-b3b3-bc7c346e7bab) | ![image](https://github.com/user-attachments/assets/bd7beac3-a366-49ad-8ba5-140de047414a) |