### PR TITLE
add completion command to generate completion script

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -20,6 +20,9 @@ This CLI provides an interface to guide you through different steps:
 npm i -g @iexec/iapp-maker
 ```
 
+> ℹ️ when you install this package for the fist time, run `iapp completion` to
+> generate a completion script for the `iapp` command
+
 ## Commands
 
 ### `--help`

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -143,6 +143,7 @@ yargsInstance
   )
 
   .help()
+  .completion('completion', false) // create hidden "completion" command
   .alias('help', 'h')
   .alias('version', 'v')
   .strict() // show help if iapp is invoked with an invalid subcommand


### PR DESCRIPTION
# Feature

Add `iapp completion` hidden command (not displayed in `help` or suggested by completion) to generate completion script

## Usage note

in `README.md`
![image](https://github.com/user-attachments/assets/907b165e-0fa1-49ec-b7ba-0107ae972617)

## Generate the script

NB: generated script depends on the user's current shell
![image](https://github.com/user-attachments/assets/9732430e-aec6-4991-a6aa-5f32ae17b5d7)

## After installing the completion script

![image](https://github.com/user-attachments/assets/414ddd07-a509-48b6-9423-05c681491680)

