### PR TITLE
retry on API 429 response

### DIFF
--- a/cli/src/utils/sleep.js
+++ b/cli/src/utils/sleep.js
@@ -1,0 +1,1 @@
+export const sleep = async (ms) => new Promise((res) => setTimeout(res, ms));


### PR DESCRIPTION
# Handle too many requests

When TEE transformation demand is too high, the TEE transformation server stops accepting transformation requests and answers with status 429 until pending requests are fulfilled.

## Changes

When running `iapp deploy`, if the servers answer with status 429 the command will seamlessly retry calling the server 3 times with exponential backoff (20s, 40s, 80s). After 3 unsuccessful attempts, the command will fail.

![image](https://github.com/user-attachments/assets/02d2ec86-bde2-495d-96f9-14a1612e4ef6)
