### PR TITLE
Feature/improve readme

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -86,7 +86,8 @@ Options:
 - use `--requesterSecret <key=value...>` to provide one or more
   [requester secrets](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#requester-secrets)
   to your iApp during testing.
-- use `--protectedData [mock-name]` if your iApp processes protected data,
+- use `--protectedData [mock-name]` if your iApp processes
+  [protected data](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#protected-data),
   include the `--protectedData` option followed by the name of a protected data
   mock.
 
@@ -121,11 +122,16 @@ Description: Run your deployed iApp. Provide the address of your iApp
 
 Options:
 
-- use `--args <args>` to provide input arguments to your iApp during run (use
-  quotes to provide multiple args).
-- use `--protectedData <address>` if your iApp processes protected data, include
-  the `--protectedData` option followed by the address of the protected data.
-- use `--inputFile <url...>` to provide one or more input files to your iApp
-  during run.
-- use `--requesterSecret <key=value...>` to provide one or more requester
-  secrets to your iApp during run.
+- use `--args <args>` to provide input
+  [arguments](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#args)
+  to your iApp during run (use quotes to provide multiple args).
+- use `--inputFile <url...>` to provide one or more
+  [input files](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#input-files)
+  to your iApp during run.
+- use `--requesterSecret <key=value...>` to provide one or more
+  [requester secrets](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#requester-secrets)
+  to your iApp during run.
+- use `--protectedData <address>` if your iApp processes
+  [protected data](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#protected-data),
+  include the `--protectedData` option followed by the address of the protected
+  data.

--- a/cli/templates/common/README.md
+++ b/cli/templates/common/README.md
@@ -62,11 +62,11 @@ iapp test
 >   [requester secrets](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#requester-secrets)
 > - `--protectedData [mock name]` simulates the app invocation with a secret
 >   [protected data](https://protocol.docs.iex.ec/for-developers/technical-references/application-iohttps://protocol.docs.iex.ec/for-developers/technical-references/application-io#protected-data)
-> - if your uses an
->   [app secret](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#app-developer-secret) >
+> - if your app uses an
+>   [app secret](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#app-developer-secret),
 >   `iapp test` will prompt you to set the app secret and simulate the run of
->   the app with it, you can save it for further reuse by `iapp test` and
->   `iapp deploy`
+>   the app with it. You can choose to save the secret for further reuse by
+>   `iapp test` and `iapp deploy`
 
 Check the test output in the [output](./output/) directory
 
@@ -85,11 +85,9 @@ iapp deploy
 > ℹ️ for apps using an
 > [app secret](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#app-developer-secret)
 >
-> The app secret is provisioned at the app deployment time, if you selected to
-> use an
-> [app secret](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#app-developer-secret) >
-> `iapp deploy` will reuse the secret provided to `iapp test` and saved in
-> [iapp.config.json](./iapp.config.json).
+> The app secret is provisioned once, at the app deployment time. If an app
+> secret was already provided to `iapp test` and saved in
+> [iapp.config.json](./iapp.config.json), `iapp deploy` will reuse this secret.
 
 ### Run on iExec
 

--- a/cli/templates/common/README.md
+++ b/cli/templates/common/README.md
@@ -37,7 +37,7 @@ This project was scaffolded with `iapp init`.
 
 `iapp init` scaffolds a ready to hack iApp template.
 
-Start hacking by editing the source code in [./src](./src/)
+Start hacking by editing the source code in [./src](./src/).
 
 See [iApp development guidelines](#iapp-development-guidelines) for more details
 on the iApp development framework.
@@ -55,20 +55,20 @@ iapp test
 > [inputs](#iapp-inputs):
 >
 > - `--args <args>` simulates the app invocation with public input
->   [args](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#args)
+>   [args](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#args).
 > - `--inputFile <url>` simulates the app invocation with public
->   [input files](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#input-files)
+>   [input files](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#input-files).
 > - `--requesterSecret <index=value>` simulates the app invocation with
->   [requester secrets](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#requester-secrets)
+>   [requester secrets](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#requester-secrets).
 > - `--protectedData [mock name]` simulates the app invocation with a secret
->   [protected data](https://protocol.docs.iex.ec/for-developers/technical-references/application-iohttps://protocol.docs.iex.ec/for-developers/technical-references/application-io#protected-data)
+>   [protected data](https://protocol.docs.iex.ec/for-developers/technical-references/application-iohttps://protocol.docs.iex.ec/for-developers/technical-references/application-io#protected-data).
 > - if your app uses an
 >   [app secret](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#app-developer-secret),
 >   `iapp test` will prompt you to set the app secret and simulate the run of
 >   the app with it. You can choose to save the secret for further reuse by
->   `iapp test` and `iapp deploy`
+>   `iapp test` and `iapp deploy`.
 
-Check the test output in the [output](./output/) directory
+Check the test output in the [output](./output/) directory.
 
 > ℹ️ Files used by the app while running `iapp test` are located in the
 > [input](./input/) directory.
@@ -91,7 +91,7 @@ iapp deploy
 
 ### Run on iExec
 
-Use the `run` command to run a deployed app on the iExec decentralized platform
+Use the `run` command to run a deployed app on the iExec decentralized platform.
 
 ```sh
 iapp run <iapp-address>
@@ -112,13 +112,13 @@ iapp run <iapp-address>
 
 - [iapp.config.json](./iapp.config.json) configuration file for the `iapp`
   commands (⚠️ this file contains sensitive information such as credentials or
-  wallet and should never be commited in a public repository)
-- [src/](./src/) where your code lives when you [develop](#develop) your app
-- [Dockerfile](./Dockerfile) how to build your app docker image
-- [input/](./input/) input directory for your [local tests](#test-locally)
-- [output/](./output/) output directory for your [local tests](#test-locally)
+  wallet and should never be committed in a public repository).
+- [src/](./src/) where your code lives when you [develop](#develop) your app.
+- [Dockerfile](./Dockerfile) how to build your app docker image.
+- [input/](./input/) input directory for your [local tests](#test-locally).
+- [output/](./output/) output directory for your [local tests](#test-locally).
 - [cache/](./cache/) directory contains traces of your past app
-  [deployments](#deploy-on-iexec) and [runs](#run-on-iexec)
+  [deployments](#deploy-on-iexec) and [runs](#run-on-iexec).
 
 ## iApp development guidelines
 
@@ -128,7 +128,7 @@ such an application.
 
 ### iApp inputs
 
-iApps can process different kind of inputs
+iApps can process different kind of inputs:
 
 - Requester inputs:
 
@@ -179,7 +179,7 @@ same deterministic result).
 ### working with libraries
 
 iApp can use libraries as soon as these libraries are installed while building
-the project's [`Dockerfile`](./Dockerfile)
+the project's [`Dockerfile`](./Dockerfile).
 
 > ℹ️ **Limitation**
 >

--- a/cli/templates/common/README.md
+++ b/cli/templates/common/README.md
@@ -1,53 +1,95 @@
 # iApp hello-world
 
-This project is an iExec decentralized application scaffolded with `iapp init`
+This project is an iExec Decentralized Confidential Computing serverless
+application leveraging Trusted Execution Environment (TEE).
 
-## Prerequisites
+This project was scaffolded with `iapp init`.
+
+- [Quick start](#quick-start)
+  - [Prerequisites](#prerequisites)
+  - [`iapp` main commands](#iapp-main-commands)
+  - [Develop](#develop)
+  - [Test locally](#test-locally)
+  - [Deploy on iExec](#deploy-on-iexec)
+  - [Run on iExec](#run-on-iexec)
+- [Project overview](#project-overview)
+- [iApp development guidelines](#iapp-development-guidelines)
+  - [iApp inputs](#iapp-inputs)
+  - [iApp outputs](#iapp-outputs)
+  - [working with libraries](#working-with-libraries)
+
+## Quick start
+
+### Prerequisites
 
 - `iapp` CLI installed locally
 - `docker` installed locally
 - [dockerhub](https://hub.docker.com/) account
 - ethereum wallet
 
-## Project overview
+### `iapp` main commands
 
-- [iapp.config.json](./iapp.config.json) configuration file for the `iapp`
-  commands
-- [src/](./src/) where your code lives when you [develop](#develop) your app
-- [Dockerfile](./Dockerfile) how to build your app docker image
-- [input/](./input/) input directory for your [local tests](#test-locally)
-- [output/](./output/) output directory for your [local tests](#test-locally)
-- [cache/](./cache/) directory contains traces of your past app
-  [deployments](#deploy-on-iexec) and [runs](#run-on-iexec)
+- [`iapp init`](#develop)
+- [`iapp test`](#test-locally)
+- [`iapp deploy`](#deploy-on-iexec)
 
 ### Develop
 
-Start hacking in [./src](./src/)
+`iapp init` scaffolds a ready to hack iApp template.
+
+Start hacking by editing the source code in [./src](./src/)
+
+See [iApp development guidelines](#iapp-development-guidelines) for more details
+on the iApp development framework.
 
 ### Test locally
 
-Use the `test` command to run your app locally
+Use the `iapp test` command to run your app locally and check your app fulfills
+the framework's [requirements for outputs](#iapp-outputs).
 
 ```sh
 iapp test
 ```
 
+> ℹ️ Use the following **options** with `iapp test` to simulate
+> [inputs](#iapp-inputs):
+>
+> - `--args <args>` simulates the app invocation with public input
+>   [args](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#args)
+> - `--inputFile <url>` simulates the app invocation with public
+>   [input files](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#input-files)
+> - `--requesterSecret <index=value>` simulates the app invocation with
+>   [requester secrets](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#requester-secrets)
+> - `--protectedData [mock name]` simulates the app invocation with a secret
+>   [protected data](https://protocol.docs.iex.ec/for-developers/technical-references/application-iohttps://protocol.docs.iex.ec/for-developers/technical-references/application-io#protected-data)
+> - if your uses an
+>   [app secret](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#app-developer-secret) >
+>   `iapp test` will prompt you to set the app secret and simulate the run of
+>   the app with it, you can save it for further reuse by `iapp test` and
+>   `iapp deploy`
+
 Check the test output in the [output](./output/) directory
 
-> ⚠️ **Output size limitation:**  
-> The results uploaded by the worker must not exceed **50 MB**.  
-> If the size exceeds this limit, the task will fail with the error
-> `POST_COMPUTE_FAILED_UNKNOWN_ISSUE`.  
-> Ensure your iApp generates outputs within this limit during testing.
+> ℹ️ Files used by the app while running `iapp test` are located in the
+> [input](./input/) directory.
 
 ### Deploy on iExec
 
-Use the `deploy` command to transform your app into a TEE app and deploy it on
-the iExec decentralized platform
+Use the `iapp deploy` command to transform your app into a TEE app and deploy it
+on the iExec decentralized platform.
 
 ```sh
 iapp deploy
 ```
+
+> ℹ️ for apps using an
+> [app secret](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#app-developer-secret)
+>
+> The app secret is provisioned at the app deployment time, if you selected to
+> use an
+> [app secret](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#app-developer-secret) >
+> `iapp deploy` will reuse the secret provided to `iapp test` and saved in
+> [iapp.config.json](./iapp.config.json).
 
 ### Run on iExec
 
@@ -56,3 +98,97 @@ Use the `run` command to run a deployed app on the iExec decentralized platform
 ```sh
 iapp run <iapp-address>
 ```
+
+> ℹ️ Use the following **options** with `iapp run` to inject inputs:
+>
+> - `--args <args>` run the app with public input
+>   [args](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#args)
+> - `--inputFile <url>` run the app with public
+>   [input files](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#input-files)
+> - `--requesterSecret <index=value>` run the app with
+>   [requester secrets](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#requester-secrets)
+> - `--protectedData <protected-data-address>` run the app with a secret
+>   [protected data](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#protected-data)
+
+## Project overview
+
+- [iapp.config.json](./iapp.config.json) configuration file for the `iapp`
+  commands (⚠️ this file contains sensitive information such as credentials or
+  wallet and should never be commited in a public repository)
+- [src/](./src/) where your code lives when you [develop](#develop) your app
+- [Dockerfile](./Dockerfile) how to build your app docker image
+- [input/](./input/) input directory for your [local tests](#test-locally)
+- [output/](./output/) output directory for your [local tests](#test-locally)
+- [cache/](./cache/) directory contains traces of your past app
+  [deployments](#deploy-on-iexec) and [runs](#run-on-iexec)
+
+## iApp development guidelines
+
+iApps are serverless Decentralized Confidential Computing applications running
+on iExec's decentralized workers. This framework gives the guidelines to build
+such an application.
+
+### iApp inputs
+
+iApps can process different kind of inputs
+
+- Requester inputs:
+
+  - public
+    [args](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#args)
+  - public
+    [input files](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#input-files)
+  - [requester secrets](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#requester-secrets)
+
+- App developer inputs
+
+  - [app secret](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#app-developer-secret)
+
+- Third party inputs:
+
+  - secret
+    [protected data](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#protected-data)
+
+### iApp outputs
+
+iApp's must write
+[output](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#application-outputs)
+files in the `IEXEC_OUT` (`/iexec_out/`) directory.
+
+Each iApp run must produce a specific [`computed.json`](#computedjson) file.
+
+> ⚠️ **Output size limitation:**  
+> The results uploaded by the worker must not exceed **50 MB**.  
+> If the size exceeds this limit, the task will fail with the error
+> `POST_COMPUTE_FAILED_UNKNOWN_ISSUE`.  
+> Ensure your iApp generates outputs within this limit during testing.
+
+#### `computed.json`
+
+The `computed.json` file is a JSON file referencing a deterministic result in
+the `IEXEC_OUT` directory (any iApp run with the same inputs should create the
+same deterministic result).
+
+```json
+{
+  "deterministic-output-path": "iexec_out/path/to/deterministic/result"
+}
+```
+
+> ℹ️ Only files referenced in `deterministic-output-path` must be deterministic,
+> other files produced in the `IEXEC_OUT` directory can be non-deterministic.
+
+### working with libraries
+
+iApp can use libraries as soon as these libraries are installed while building
+the project's [`Dockerfile`](./Dockerfile)
+
+> ℹ️ **Limitation**
+>
+> Transforming an app into a TEE application requires a base image (image
+> `FROM`) compatible with the transformation. Currently only a small set of base
+> images are available.
+>
+> - make sure installed libraries can run within the base image
+> - do not try to replace the base image in the Dockerfile, this would lead to
+>   failing TEE transformation.


### PR DESCRIPTION
# `iapp init` README

Change the `README.md` generated when the user init a new project with `iapp init`

Motivation: give the developer more insights about iApp development to avoid common pitfalls.

preview: https://github.com/iExecBlockchainComputing/iapp/blob/feature/improve-readme/cli/templates/common/README.md

Featuring:
- quick start
- links to protocol documentation
- iApp development guidelines