### PR TITLE
use project name to name docker image and iexec app

### DIFF
--- a/cli/src/cmd/deploy.js
+++ b/cli/src/cmd/deploy.js
@@ -6,7 +6,10 @@ import {
 import { sconify } from '../utils/sconify.js';
 import { askForDockerhubUsername } from '../cli-helpers/askForDockerhubUsername.js';
 import { askForWalletAddress } from '../cli-helpers/askForWalletAddress.js';
-import { readPackageJonConfig } from '../utils/iAppConfigFile.js';
+import {
+  projectNameToImageName,
+  readIAppConfig,
+} from '../utils/iAppConfigFile.js';
 import { askForDockerhubAccessToken } from '../cli-helpers/askForDockerhubAccessToken.js';
 import { handleCliError } from '../cli-helpers/handleCliError.js';
 import { getSpinner } from '../cli-helpers/spinner.js';
@@ -22,6 +25,8 @@ export async function deploy() {
   const spinner = getSpinner();
   try {
     await goToProjectRoot({ spinner });
+    const { projectName } = await readIAppConfig();
+
     const dockerhubUsername = await askForDockerhubUsername({ spinner });
     const dockerhubAccessToken = await askForDockerhubAccessToken({ spinner });
 
@@ -38,6 +43,8 @@ export async function deploy() {
       throw Error('Invalid version');
     }
 
+    const imageTag = `${dockerhubUsername}/${projectNameToImageName(projectName)}:${iAppVersion}`;
+
     const appSecret = await askForAppSecret({ spinner });
 
     const walletAddress = await askForWalletAddress({ spinner });
@@ -53,11 +60,6 @@ export async function deploy() {
       }
       iexec = getIExecDebug(privateKey);
     }
-
-    const config = await readPackageJonConfig();
-    const iAppName = config.name.toLowerCase();
-
-    const imageTag = `${dockerhubUsername}/${iAppName}:${iAppVersion}`;
 
     // just start the spinner, no need to persist success in terminal
     spinner.start('Checking docker daemon is running...');

--- a/cli/src/cmd/init.js
+++ b/cli/src/cmd/init.js
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import figlet from 'figlet';
 import { mkdir } from 'node:fs/promises';
+import { fromError } from 'zod-validation-error';
 import { folderExists } from '../utils/fs.utils.js';
 import { initIAppWorkspace } from '../utils/initIAppWorkspace.js';
 import { getSpinner } from '../cli-helpers/spinner.js';
@@ -8,6 +9,7 @@ import { handleCliError } from '../cli-helpers/handleCliError.js';
 import { generateWallet } from '../utils/generateWallet.js';
 import * as color from '../cli-helpers/color.js';
 import { hintBox } from '../cli-helpers/box.js';
+import { projectNameSchema } from '../utils/iAppConfigFile.js';
 
 const targetDir = 'hello-world';
 
@@ -30,6 +32,16 @@ export async function init() {
       name: 'projectName',
       message: `What's your project name? ${color.promptHelper('(A folder with this name will be created)')}`,
       initial: targetDir,
+      validate: (value) => {
+        try {
+          projectNameSchema.parse(value);
+          return true;
+        } catch (e) {
+          return fromError(e)
+            .details.map((issue) => issue.message)
+            .join('; ');
+        }
+      },
     });
 
     if (await folderExists(projectName)) {

--- a/cli/src/utils/iAppConfigFile.js
+++ b/cli/src/utils/iAppConfigFile.js
@@ -3,14 +3,39 @@ import { z } from 'zod';
 import { fromError } from 'zod-validation-error';
 import { CONFIG_FILE } from '../config/config.js';
 
+export const projectNameSchema = z
+  .string()
+  .min(2, 'Must contain at least 2 characters') // docker image name constraint
+  .refine(
+    (value) => !/(^\s)|(\s$)/.test(value),
+    'Should not start or end with space'
+  )
+  .refine(
+    (value) => /^[a-zA-Z0-9- ]+$/.test(value ?? ''),
+    'Only letters, numbers, spaces, and hyphens are allowed'
+  );
+
+const dockerImageNameSchema = z
+  .string()
+  .refine(
+    (value) => /^[a-z0-9-]+$/.test(value ?? ''),
+    'Invalid docker image name'
+  );
+
 const jsonConfigFileSchema = z.object({
-  projectName: z.string(),
+  projectName: projectNameSchema,
   dockerhubUsername: z.string().optional(),
   dockerhubAccessToken: z.string().optional(),
   walletAddress: z.string().optional(),
   walletPrivateKey: z.string().optional(),
   appSecret: z.string().optional().nullable(), // can be null or string (null means do no use secret)
 });
+
+// transform the projectName into a suitable docker image name (no space, lowercase only)
+export function projectNameToImageName(projectName = '') {
+  const imageName = projectName.toLowerCase().replaceAll(' ', '-');
+  return dockerImageNameSchema.parse(imageName);
+}
 
 // Read JSON configuration file
 export async function readIAppConfig() {
@@ -34,16 +59,6 @@ export async function readIAppConfig() {
     const validationError = fromError(err);
     const errorMessage = `Failed to read \`${CONFIG_FILE}\` file: ${validationError.toString()}`;
     throw Error(errorMessage);
-  }
-}
-
-// Read package.json file
-export async function readPackageJonConfig() {
-  try {
-    const packageContent = await readFile('./package.json', 'utf8');
-    return JSON.parse(packageContent);
-  } catch {
-    throw Error('Failed to read `package.json` file.');
   }
 }
 


### PR DESCRIPTION
# use project name to name docker image and iexec app

- replace name from `package.json` (JS specific) with `projectName` defined in `iapp.cof.json`
- new restriction on project name
  - 2 characters min (suitable for docker image name) 
  - letters, numbers, hyphens, and space only
  - name must be trimed
- project name to image name transformation
  - replace space (not supported by docker) by hyphens (space are still allowed in project name because some user like names with spaces...) 
  - lowercase name