### PR TITLE
Feature/error handling in template

### DIFF
--- a/cli/src/cmd/test.js
+++ b/cli/src/cmd/test.js
@@ -209,9 +209,8 @@ export async function testApp({
   } else if (exitCode === 0) {
     spinner.succeed('App docker image ran and exited successfully.');
   } else {
-    spinner.warn(
-      `App docker image ran but exited with error (Exit code: ${exitCode})
-  You may want to check it was intentional`
+    spinner.error(
+      `App docker image ran but exited with error (Exit code: ${exitCode})`
     );
   }
   // show app logs

--- a/cli/src/config/config.js
+++ b/cli/src/config/config.js
@@ -13,7 +13,7 @@ export const RUN_OUTPUT_DIR = 'output'; // Same as TEST_OUTPUT_DIR
 export const CACHE_DIR = 'cache';
 export const PROTECTED_DATA_MOCK_DIR = 'mock/protectedData';
 
-export const IEXEC_OUT = '/iexec_out/';
+export const IEXEC_OUT = '/iexec_out';
 export const IEXEC_COMPUTED_JSON = 'computed.json';
 export const IEXEC_DETERMINISTIC_OUTPUT_PATH_KEY = 'deterministic-output-path';
 export const IEXEC_WORKER_HEAP_SIZE = 1024 * 1024 * 1024; // iExec worker memory limit (1 GiB)

--- a/cli/templates/js/src/app.js
+++ b/cli/templates/js/src/app.js
@@ -6,9 +6,11 @@ import { IExecDataProtectorDeserializer } from '@iexec/dataprotector-deserialize
 
 // ⚠️ Your JavaScript code will be run in a Node.js v14.4 environment with npm v6.
 const main = async () => {
-  try {
-    const { IEXEC_OUT } = process.env;
+  const { IEXEC_OUT } = process.env;
 
+  let computedJsonObj = {};
+
+  try {
     let messages = [];
     // <<args>>
 
@@ -83,17 +85,25 @@ const main = async () => {
     // Write result to IEXEC_OUT
     await fs.writeFile(`${IEXEC_OUT}/result.txt`, asciiArtText);
 
-    // Build and save a "computed.json" file
-    const computedJsonObj = {
+    // Build the "computed.json" object
+    computedJsonObj = {
       'deterministic-output-path': `${IEXEC_OUT}/result.txt`,
     };
+  } catch (e) {
+    // Handle errors
+    console.log(e);
+
+    // Build the "computed.json" object with an error message
+    computedJsonObj = {
+      'deterministic-output-path': IEXEC_OUT,
+      'error-message': 'Oops something went wrong',
+    };
+  } finally {
+    // Save the "computed.json" file
     await fs.writeFile(
       `${IEXEC_OUT}/computed.json`,
       JSON.stringify(computedJsonObj)
     );
-  } catch (e) {
-    console.log(e);
-    process.exit(1);
   }
 };
 


### PR DESCRIPTION
In current worker implementation, App exiting with non-zero code or without producing a valid `computed.json` prevents the worker from contributing.

This PR changes the template to follow these app developement guidelines and introduces the "error-message" field in `computed.json`