### PR TITLE
detect sconification error based on container exit code (not logs)

### DIFF
--- a/api/src/singleFunction/sconifyImage.js
+++ b/api/src/singleFunction/sconifyImage.js
@@ -67,7 +67,7 @@ export async function sconifyImage({ fromImage, entrypoint }) {
 
     const inspect = await sconifyContainer.inspect();
     if (inspect.State.ExitCode !== 0) {
-      logger.warn(inspect.State, 'Sconify container exited with non-zero code');
+      logger.error(inspect.State, 'Sconify container exited with non-zero code');
       throw Error(
         `Sconify container exited with error (code: ${inspect.State.ExitCode})`
       );

--- a/api/src/singleFunction/sconifyImage.js
+++ b/api/src/singleFunction/sconifyImage.js
@@ -67,7 +67,10 @@ export async function sconifyImage({ fromImage, entrypoint }) {
 
     const inspect = await sconifyContainer.inspect();
     if (inspect.State.ExitCode !== 0) {
-      logger.error(inspect.State, 'Sconify container exited with non-zero code');
+      logger.error(
+        inspect.State,
+        'Sconify container exited with non-zero code'
+      );
       throw Error(
         `Sconify container exited with error (code: ${inspect.State.ExitCode})`
       );

--- a/api/src/singleFunction/sconifyImage.js
+++ b/api/src/singleFunction/sconifyImage.js
@@ -49,7 +49,6 @@ export async function sconifyImage({ fromImage, entrypoint }) {
 
   try {
     await sconifyContainer.start();
-    let hasError = false;
     sconifyContainer.attach(
       { stream: true, stdout: true, stderr: true },
       function (err, stream) {
@@ -57,25 +56,21 @@ export async function sconifyImage({ fromImage, entrypoint }) {
           logger.error(err, 'Error attaching to container');
           return;
         }
-
-        // Try to detect any 'docker build' error, otherwise log to stdout
         stream.on('data', function (data) {
           const readableData = data.toString('utf8');
           logger.debug(readableData);
-          if (readableData.toLowerCase().includes('error')) {
-            logger.error(
-              { data: readableData },
-              'Sconify docker container error'
-            );
-            hasError = true;
-          }
         });
       }
     );
     // TODO maybe add a timeout?
     await sconifyContainer.wait();
-    if (hasError) {
-      throw new Error('Error at sconify process');
+
+    const inspect = await sconifyContainer.inspect();
+    if (inspect.State.ExitCode !== 0) {
+      logger.warn(inspect.State, 'Sconify container exited with non-zero code');
+      throw Error(
+        `Sconify container exited with error (code: ${inspect.State.ExitCode})`
+      );
     }
   } finally {
     logger.info(


### PR DESCRIPTION
#  Issue :bug: sconification of images with `error` in name fails

image name logging triggered the former error detection code

## fix

Use the sconification container exit code to detect issues.

![image](https://github.com/user-attachments/assets/3c03572f-4b05-402d-b0bd-68b821876a16)

![image](https://github.com/user-attachments/assets/f1395cce-80d0-435d-af8d-cd5237ae2944)

