### PR TITLE
display and save taskid for later debugging

### DIFF
--- a/cli/src/cmd/run.js
+++ b/cli/src/cmd/run.js
@@ -184,19 +184,21 @@ export async function runInDebug({
     workerpoolorder,
     requestorder,
   });
-  await addRunData({ iAppAddress, dealid, txHash });
+  const taskid = await iexec.deal.computeTaskId(dealid, 0);
+  await addRunData({ iAppAddress, dealid, taskid, txHash });
   spinner.succeed(
-    `Deal created successfully, this is your deal ID: https://explorer.iex.ec/bellecour/deal/${dealid}`
+    `Deal created successfully
+  - deal: ${dealid} ${color.link(`https://explorer.iex.ec/bellecour/deal/${dealid}`)}
+  - task: ${taskid}`
   );
 
   spinner.start('Observing task...');
-  const taskId = await iexec.deal.computeTaskId(dealid, 0);
-  const taskObservable = await iexec.task.obsTask(taskId, { dealid: dealid });
+  const taskObservable = await iexec.task.obsTask(taskid, { dealid: dealid });
   const taskTimeoutWarning = setTimeout(() => {
     const spinnerText = spinner.text;
     spinner.warn('Task is taking longer than expected...');
     spinner.log(
-      `💡Tip: You can debug this task using: ${color.command(`iapp debug ${taskId}`)}`
+      `💡Tip: You can debug this task using: ${color.command(`iapp debug ${taskid}`)}`
     );
     spinner.start(spinnerText); // restart spinning
   }, TASK_OBSERVATION_TIMEOUT);
@@ -210,7 +212,7 @@ export async function runInDebug({
     clearTimeout(taskTimeoutWarning);
   });
 
-  const task = await iexec.task.show(taskId);
+  const task = await iexec.task.show(taskid);
   spinner.succeed(`Task finalized
 You can download the result of your task here: ${color.link(`https://ipfs-gateway.v8-bellecour.iex.ec${task?.results?.location}`)}`);
 
@@ -227,7 +229,7 @@ You can download the result of your task here: ${color.link(`https://ipfs-gatewa
 
   spinner.start('Downloading result...');
   const outputFolder = RUN_OUTPUT_DIR;
-  const taskResult = await iexec.task.fetchResults(taskId);
+  const taskResult = await iexec.task.fetchResults(taskid);
   const resultBuffer = await taskResult.arrayBuffer();
   await extractZipToFolder(resultBuffer, outputFolder);
   spinner.succeed(`Result downloaded to ${color.file(outputFolder)}`);

--- a/cli/src/utils/cacheExecutions.js
+++ b/cli/src/utils/cacheExecutions.js
@@ -55,12 +55,13 @@ function getFormattedDateInParis() {
 }
 
 // Function to add run data to runs.json
-export async function addRunData({ iAppAddress, dealid, txHash }) {
+export async function addRunData({ iAppAddress, dealid, taskid, txHash }) {
   const formattedDate = getFormattedDateInParis();
   const runData = {
     date: formattedDate,
     iAppAddress,
     dealid,
+    taskid,
     txHash,
   };
   await addDataToCache('runs.json', runData);


### PR DESCRIPTION
- display taskid with dealid ASAP
![image](https://github.com/user-attachments/assets/4f6faa76-fd2e-49ed-aeb5-83b8bac35f23)
- save in `run.json` cache for easier debugging
![image](https://github.com/user-attachments/assets/a555856d-7080-4517-b099-7aeface9ec76)
