### PR TITLE
TDX PoC [DO NOT MERGE]

### DIFF
--- a/cli/src/cmd/deploy.ts
+++ b/cli/src/cmd/deploy.ts
@@ -20,6 +20,7 @@ import { getIExecDebug } from '../utils/iexec.js';
 import { goToProjectRoot } from '../cli-helpers/goToProjectRoot.js';
 import * as color from '../cli-helpers/color.js';
 import { hintBox } from '../cli-helpers/box.js';
+import { deployTdxApp, getIExecTdx, useTdx } from '../utils/tdx-poc.js';
 
 export async function deploy() {
   const spinner = getSpinner();
@@ -50,15 +51,20 @@ export async function deploy() {
     const walletAddress = await askForWalletAddress({ spinner });
 
     // if an app secret must be set we will need the app owner wallet to push it
+    // in TDX mode deployment is done by the client
     let iexec;
-    if (appSecret !== null) {
+    if (appSecret !== null || useTdx) {
       const privateKey = await askForWalletPrivateKey({ spinner });
       const wallet = new Wallet(privateKey);
       const address = await wallet.getAddress();
       if (address.toLowerCase() !== walletAddress.toLowerCase()) {
         throw Error('Provided address and private key mismatch');
       }
-      iexec = getIExecDebug(privateKey);
+      if (useTdx) {
+        iexec = getIExecTdx(privateKey);
+      } else {
+        iexec = getIExecDebug(privateKey);
+      }
     }
 
     // just start the spinner, no need to persist success in terminal
@@ -87,16 +93,28 @@ export async function deploy() {
     });
     spinner.succeed(`Pushed image ${imageTag} on dockerhub`);
 
-    spinner.start(
-      'Transforming your image into a TEE image and deploying on iExec, this may take a few minutes...'
-    );
-    const { sconifiedImage, appContractAddress } = await sconify({
-      iAppNameToSconify: imageTag,
-      template,
-      walletAddress,
-      dockerhubAccessToken,
-      dockerhubUsername,
-    });
+    let appDockerImage: string;
+    let appContractAddress: string;
+    if (useTdx && iexec) {
+      spinner.start('Deploying TDX TEE app on iExec...');
+      ({ tdxImage: appDockerImage, appContractAddress } = await deployTdxApp({
+        iexec,
+        image: imageTag,
+        dockerhubAccessToken,
+        dockerhubUsername,
+      }));
+    } else {
+      spinner.start(
+        'Transforming your image into a TEE image and deploying on iExec, this may take a few minutes...'
+      );
+      ({ sconifiedImage: appDockerImage, appContractAddress } = await sconify({
+        iAppNameToSconify: imageTag,
+        template,
+        walletAddress,
+        dockerhubAccessToken,
+        dockerhubUsername,
+      }));
+    }
     spinner.succeed('TEE app deployed');
     if (appSecret !== null && iexec) {
       spinner.start('Attaching app secret to the deployed app');
@@ -105,7 +123,7 @@ export async function deploy() {
     }
     spinner.succeed(
       `Deployment of your iApp completed successfully:
-  - Docker image: ${sconifiedImage}
+  - Docker image: ${appDockerImage}
   - iApp address: ${appContractAddress}`
     );
 

--- a/cli/src/cmd/run.ts
+++ b/cli/src/cmd/run.ts
@@ -17,6 +17,7 @@ import { askShowResult } from '../cli-helpers/askShowResult.js';
 import { goToProjectRoot } from '../cli-helpers/goToProjectRoot.js';
 import * as color from '../cli-helpers/color.js';
 import { IExec } from 'iexec';
+import { getIExecTdx, useTdx, WORKERPOOL_TDX } from '../utils/tdx-poc.js';
 
 export async function run({
   iAppAddress,
@@ -83,7 +84,12 @@ export async function runInDebug({
   const walletPrivateKey = await askForWalletPrivateKey({ spinner });
   const wallet = new ethers.Wallet(walletPrivateKey);
 
-  const iexec = getIExecDebug(walletPrivateKey);
+  let iexec: IExec;
+  if (useTdx) {
+    iexec = getIExecTdx(walletPrivateKey);
+  } else {
+    iexec = getIExecDebug(walletPrivateKey);
+  }
 
   // Make some ProtectedData preflight check
   if (protectedData) {
@@ -125,7 +131,7 @@ export async function runInDebug({
   // Workerpool Order
   spinner.start('Fetching workerpool order...');
   const workerpoolOrderbook = await iexec.orderbook.fetchWorkerpoolOrderbook({
-    workerpool: WORKERPOOL_DEBUG,
+    workerpool: useTdx ? WORKERPOOL_TDX : WORKERPOOL_DEBUG,
     app: iAppAddress,
     dataset: protectedData || ethers.ZeroAddress,
     minTag: SCONE_TAG,

--- a/cli/src/utils/tdx-poc.ts
+++ b/cli/src/utils/tdx-poc.ts
@@ -1,0 +1,101 @@
+// PoC to demonstrate use of TDX iApps with the TDX testbed
+// most of the logic is gathered in this module to limit impacts on the project
+import Docker from 'dockerode';
+import { IExec, utils } from 'iexec';
+import { pushDockerImage } from '../execDocker/docker.js';
+
+// TDX feature flag, set env EXPERIMENTAL_TDX_APP=1 to enable
+export const useTdx = !!process.env.EXPERIMENTAL_TDX_APP;
+
+// TODO move this constant
+export const WORKERPOOL_TDX = 'tdx-labs.pools.iexec.eth';
+
+// TODO move this logic
+export function getIExecTdx(privateKey: string): IExec {
+  return new IExec(
+    {
+      ethProvider: utils.getSignerFromPrivateKey('bellecour', privateKey),
+    },
+    {
+      smsURL: 'https://sms.labs.iex.ec',
+    }
+  );
+}
+
+const docker = new Docker();
+// TODO move this logic to docker.ts
+async function tagDockerImage({
+  image,
+  repo,
+  tag,
+}: {
+  image: string;
+  repo: string;
+  tag: string;
+}) {
+  const dockerImage = docker.getImage(image);
+  await dockerImage.tag({
+    repo,
+    tag,
+  });
+  return `${repo}:${tag}`;
+}
+// TODO move this logic to docker.ts
+function inspectImage(image: string) {
+  const img = docker.getImage(image);
+  return img.inspect();
+}
+
+function parseImagePath(dockerImagePath: string) {
+  const dockerUserName = dockerImagePath.split('/')[0];
+  const nameWithTag = dockerImagePath.split('/')[1];
+  const imageName = nameWithTag.split(':')[0];
+  const imageTag = nameWithTag.split(':')[1] || 'latest';
+  return { dockerUserName, imageName, imageTag };
+}
+
+export const deployTdxApp = async ({
+  iexec,
+  image,
+  dockerhubUsername,
+  dockerhubAccessToken,
+}: {
+  iexec: IExec;
+  image: string;
+  dockerhubUsername: string;
+  dockerhubAccessToken: string;
+}) => {
+  const { dockerUserName, imageName, imageTag } = parseImagePath(image);
+  const repo = `${dockerUserName}/${imageName}`;
+  const inspectResult = await inspectImage(image);
+
+  const appEntrypoint = Array.isArray(inspectResult.Config.Entrypoint)
+    ? inspectResult.Config.Entrypoint.join(' ')
+    : inspectResult.Config.Entrypoint;
+
+  const tdxImageShortId = inspectResult.Id.substring(7, 7 + 12); // extract 12 first chars after the leading "sha256:"
+  const tdxImageTag = `${imageTag}-tdx-${tdxImageShortId}`; // add digest in tag to avoid replacing previous build
+  const taggedImage = await tagDockerImage({ image, repo, tag: tdxImageTag });
+  await pushDockerImage({
+    tag: taggedImage,
+    dockerhubUsername,
+    dockerhubAccessToken,
+  });
+  const { address } = await iexec.app.deployApp({
+    owner: await iexec.wallet.getAddress(),
+    name: `TDX POC ${imageName}-${imageTag}`,
+    type: 'DOCKER',
+    multiaddr: taggedImage,
+    checksum: `0x${inspectResult.RepoDigests[0].split('@sha256:')[1]}`,
+    mrenclave: {
+      // TODO TDX does not exists for now in iexec SDK, using SCONE shaped mrenclave for the PoC
+      framework: 'SCONE', // TODO TBD should be TDX
+      version: 'TDX-POC', // TODO TBD
+      entrypoint: appEntrypoint,
+      heapSize: 1073741824, // TODO not needed for TDX, set to pass scone mrenclave validation
+      fingerprint:
+        '0ce518e5df689f59ffae43c38746d087fab60f409b7c959bfe4fc6c67bc179be', // TODO not needed for TDX, used keccak256("TDX-POC") to pass scone mrenclave validation
+    },
+  });
+  return { tdxImage: taggedImage, appContractAddress: address };
+};


### PR DESCRIPTION
# PoC

Use `iapp` with TDX testbed to **deploy** and **run** TDX iApps

## Disclaimer

This PoC has many shortcuts and should NOT be merged or used for anything other than testing and prototyping.

## Usage

### install `iapp` CLI

install globally

```sh
git checkout poc-tdx-do-not-merge
git pull
cd cli
npm ci
npm run build
npm i -g .
```

check install

```sh
iapp -v
```

### use TDX app mode

use env `EXPERIMENTAL_TDX_APP=1` to enable TDX app mode.

```sh
EXPERIMENTAL_TDX_APP=1 iapp deploy
EXPERIMENTAL_TDX_APP=1 iapp run <app-address>
```