### PR TITLE
feat: support Scone v5.9

### DIFF
--- a/api/src/constants/constants.ts
+++ b/api/src/constants/constants.ts
@@ -3,9 +3,19 @@ export const SCONE_NODE_IMAGE =
   'registry.scontain.com:5050/sconecuratedimages/node:14.4.0-alpine3.11';
 
 // https://gitlab.scontain.com/scone-production/iexec-sconify-image/container_registry/99?after=NTA
-export const SCONIFY_IMAGE_VERSION = '5.7.6-v15';
+export const SCONIFY_IMAGE_NAME = `registry.scontain.com/scone-production/iexec-sconify-image`;
 
-export const SCONIFY_IMAGE = `registry.scontain.com/scone-production/iexec-sconify-image:${SCONIFY_IMAGE_VERSION}`;
+/**
+ * Scone version as defined in apps contracts (mrenclave.version)
+ *
+ * NB: "v5" is the legacy scone version v5.7 (name constrained by version parsing in workerpool)
+ */
+export type SconeVersion = 'v5' | 'v5.9';
+
+export const SCONIFY_IMAGE_VERSIONS: Record<SconeVersion, string> = {
+  v5: '5.7.6-v15',
+  'v5.9': '5.9.0-v15',
+};
 
 // This SCONIFY_IMAGE depends on Linux alpine:3.15
 // It will be pulled if it's not yet in the local docker
@@ -18,19 +28,18 @@ export const TEMPLATE_CONFIG: Record<
   {
     template: TemplateName;
     binary: string;
-    sconeImage: string;
+    sconeCuratedImage?: string;
   }
 > = {
   JavaScript: {
     template: 'JavaScript',
     binary: '/usr/local/bin/node',
-    sconeImage:
+    sconeCuratedImage:
       'registry.scontain.com:5050/sconecuratedimages/node:14.4.0-alpine3.11',
   },
   Python: {
     template: 'Python',
     binary: '/usr/local/bin/python3.8',
-    sconeImage: '',
   },
 };
 

--- a/api/src/constants/constants.ts
+++ b/api/src/constants/constants.ts
@@ -26,19 +26,16 @@ export type TemplateName = 'JavaScript' | 'Python';
 export const TEMPLATE_CONFIG: Record<
   TemplateName,
   {
-    template: TemplateName;
     binary: string;
     sconeCuratedImage?: string;
   }
 > = {
   JavaScript: {
-    template: 'JavaScript',
     binary: '/usr/local/bin/node',
     sconeCuratedImage:
       'registry.scontain.com:5050/sconecuratedimages/node:14.4.0-alpine3.11',
   },
   Python: {
-    template: 'Python',
     binary: '/usr/local/bin/python3.8',
   },
 };

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,9 +2,9 @@ import { readFile } from 'node:fs/promises';
 import express from 'express';
 import { pino } from 'pino';
 import {
-  sconifyHttpHandler,
-  sconifyWsHandler,
-} from './sconify/sconify.handler.js';
+  deprecated_sconifyHttpHandler,
+  deprecated_sconifyWsHandler,
+} from './sconify/deprecated_sconify.handler.js';
 import { loggerMiddleware } from './utils/logger.js';
 import { requestIdMiddleware } from './utils/requestId.js';
 import { errorHandlerMiddleware } from './utils/errors.js';
@@ -31,7 +31,9 @@ app.use(express.json());
 app.use(requestIdMiddleware);
 app.use(loggerMiddleware);
 
-app.post('/sconify', sconifyHttpHandler);
+// deprecated endpoint, clients should use /sconify/build
+app.post('/sconify', deprecated_sconifyHttpHandler);
+
 app.post('/sconify/build', sconifyBuildHttpHandler);
 
 // Health endpoint
@@ -56,8 +58,9 @@ const server = app.listen(port, hostname, () => {
 attachWebSocketServer({
   server,
   requestRouter: (requestTarget) => {
+    // deprecated requestTarget, clients should use SCONIFY_BUILD
     if (requestTarget === 'SCONIFY') {
-      return sconifyWsHandler;
+      return deprecated_sconifyWsHandler;
     }
     if (requestTarget === 'SCONIFY_BUILD') {
       return sconifyBuildWsHandler;

--- a/api/src/sconify/deprecated_sconify.handler.ts
+++ b/api/src/sconify/deprecated_sconify.handler.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { createMessageBuilder, fromError } from 'zod-validation-error';
 import { TEMPLATE_CONFIG, type TemplateName } from '../constants/constants.js';
 import { ethereumAddressZodSchema } from '../utils/ethereumAddressZodSchema.js';
-import { sconify } from './sconify.service.js';
+import { deprecated_sconify } from './deprecated_sconify.service.js';
 import type { Request, Response } from 'express';
 
 const bodySchema = z.object({
@@ -48,7 +48,7 @@ async function handleSconifyRequest(requestObj: object) {
       }),
     });
   }
-  const { sconifiedImage, appContractAddress } = await sconify({
+  const { sconifiedImage, appContractAddress } = await deprecated_sconify({
     dockerImageToSconify: dockerhubImageToSconify,
     pushToken: dockerhubPushToken,
     userWalletPublicAddress: yourWalletPublicAddress,
@@ -57,13 +57,16 @@ async function handleSconifyRequest(requestObj: object) {
   return { sconifiedImage, appContractAddress };
 }
 
-export async function sconifyWsHandler(message: object) {
+export async function deprecated_sconifyWsHandler(message: object) {
   const { sconifiedImage, appContractAddress } =
     await handleSconifyRequest(message);
   return { sconifiedImage, appContractAddress };
 }
 
-export async function sconifyHttpHandler(req: Request, res: Response) {
+export async function deprecated_sconifyHttpHandler(
+  req: Request,
+  res: Response
+) {
   const { sconifiedImage, appContractAddress } = await handleSconifyRequest(
     req.body || {}
   );

--- a/api/src/sconify/deprecated_sconify.handler.ts
+++ b/api/src/sconify/deprecated_sconify.handler.ts
@@ -21,12 +21,8 @@ const bodySchema = z.object({
       'An auth token with push access to dockerhub repository is required.'
     ),
   template: z
-    .enum(
-      Object.values(TEMPLATE_CONFIG).map((config) => config.template) as [
-        TemplateName,
-      ]
-    )
-    .default(TEMPLATE_CONFIG.JavaScript.template),
+    .enum(Object.keys(TEMPLATE_CONFIG) as [TemplateName])
+    .default('JavaScript'),
 });
 
 async function handleSconifyRequest(requestObj: object) {

--- a/api/src/sconify/deprecated_sconify.service.ts
+++ b/api/src/sconify/deprecated_sconify.service.ts
@@ -17,7 +17,7 @@ import { logger } from '../utils/logger.js';
 import { parseImagePath } from '../utils/parseImagePath.js';
 import { isWsEnabled, sendWsMessage } from '../utils/websocket.js';
 
-export async function sconify({
+export async function deprecated_sconify({
   dockerImageToSconify,
   userWalletPublicAddress,
   pushToken,

--- a/api/src/sconify/deprecated_sconify.service.ts
+++ b/api/src/sconify/deprecated_sconify.service.ts
@@ -1,5 +1,5 @@
 import {
-  SCONIFY_IMAGE_VERSION,
+  SCONIFY_IMAGE_VERSIONS,
   TEMPLATE_CONFIG,
   type TemplateName,
 } from '../constants/constants.js';
@@ -41,6 +41,9 @@ export async function deprecated_sconify({
   sconifiedImage: string;
   appContractAddress: string;
 }> {
+  // deprecated service fixed in scone v5.7
+  const sconifyVersion = SCONIFY_IMAGE_VERSIONS['v5'];
+
   let currentPushToken = pushToken;
   const wsEnabled = isWsEnabled();
 
@@ -119,15 +122,15 @@ export async function deprecated_sconify({
     }
     logger.info({ appEntrypoint }, 'Entrypoint read from image.');
 
-    // Pull the SCONE image
-    logger.info('---------- 4 ---------- Pulling Scone image');
-    if (configTemplate.sconeImage) {
-      await pullSconeImage(configTemplate.sconeImage);
+    logger.info('---------- 4 ---------- Ensure Scone curated image');
+    if (configTemplate.sconeCuratedImage) {
+      await pullSconeImage(configTemplate.sconeCuratedImage);
     }
 
     logger.info('---------- 5 ---------- Start sconification...');
     sconifiedImageId = await sconifyImage({
       fromImage: dockerImageToSconify,
+      sconifyVersion,
       entrypoint: appEntrypoint,
       binary: configTemplate.binary,
     });
@@ -156,7 +159,7 @@ export async function deprecated_sconify({
 
   const imageRepo = `${dockerUserName}/${imageName}`;
   const sconifiedImageShortId = sconifiedImageId.substring(7, 7 + 12); // extract 12 first chars after the leading "sha256:"
-  const sconifiedImageTag = `${imageTag}-tee-scone-${SCONIFY_IMAGE_VERSION}-debug-${sconifiedImageShortId}`; // add digest in tag to avoid replacing previous build
+  const sconifiedImageTag = `${imageTag}-tee-scone-${sconifyVersion}-debug-${sconifiedImageShortId}`; // add digest in tag to avoid replacing previous build
   const sconifiedImage = `${imageRepo}:${sconifiedImageTag}`;
 
   let pushed;

--- a/api/src/sconify/sconifyBuild.handler.ts
+++ b/api/src/sconify/sconifyBuild.handler.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { createMessageBuilder, fromError } from 'zod-validation-error';
-import { TEMPLATE_CONFIG, type TemplateName } from '../constants/constants.js';
+import {
+  SconeVersion,
+  TEMPLATE_CONFIG,
+  type TemplateName,
+} from '../constants/constants.js';
 import { ethereumAddressZodSchema } from '../utils/ethereumAddressZodSchema.js';
 import { sconify } from './sconifyBuild.service.js';
 import type { Request, Response } from 'express';
@@ -27,18 +31,21 @@ const bodySchema = z.object({
       ]
     )
     .default(TEMPLATE_CONFIG.JavaScript.template),
+  sconeVersion: z.enum(['v5', 'v5.9']).default('v5'),
 });
 
 async function handleSconifyRequest(requestObj: object) {
-  let yourWalletPublicAddress;
-  let dockerhubImageToSconify;
-  let dockerhubPushToken;
+  let yourWalletPublicAddress: string;
+  let dockerhubImageToSconify: string;
+  let dockerhubPushToken: string;
+  let sconeVersion: SconeVersion;
   let template: TemplateName;
   try {
     ({
       yourWalletPublicAddress,
       dockerhubImageToSconify,
       dockerhubPushToken,
+      sconeVersion,
       template,
     } = bodySchema.parse(requestObj));
   } catch (error) {
@@ -53,25 +60,49 @@ async function handleSconifyRequest(requestObj: object) {
       dockerImageToSconify: dockerhubImageToSconify,
       pushToken: dockerhubPushToken,
       userWalletPublicAddress: yourWalletPublicAddress,
+      sconeVersion,
       templateLanguage: template,
     });
-  return { dockerImage, dockerImageDigest, fingerprint, entrypoint };
+  return {
+    dockerImage,
+    dockerImageDigest,
+    fingerprint,
+    entrypoint,
+    sconeVersion,
+  };
 }
 
 export async function sconifyBuildWsHandler(message: object) {
-  const { dockerImage, dockerImageDigest, fingerprint, entrypoint } =
-    await handleSconifyRequest(message);
-  return { dockerImage, dockerImageDigest, fingerprint, entrypoint };
+  const {
+    dockerImage,
+    dockerImageDigest,
+    fingerprint,
+    entrypoint,
+    sconeVersion,
+  } = await handleSconifyRequest(message);
+  return {
+    dockerImage,
+    dockerImageDigest,
+    fingerprint,
+    entrypoint,
+    sconeVersion,
+  };
 }
 
 export async function sconifyBuildHttpHandler(req: Request, res: Response) {
-  const { dockerImage, dockerImageDigest, fingerprint, entrypoint } =
-    await handleSconifyRequest(req.body || {});
+  const {
+    dockerImage,
+    dockerImageDigest,
+    fingerprint,
+    entrypoint,
+    sconeVersion,
+  } = await handleSconifyRequest(req.body || {});
   res.status(200).json({
     success: true,
     dockerImage,
     dockerImageDigest,
     fingerprint,
     entrypoint,
+    sconeVersion,
   });
 }

--- a/api/src/sconify/sconifyBuild.handler.ts
+++ b/api/src/sconify/sconifyBuild.handler.ts
@@ -25,12 +25,8 @@ const bodySchema = z.object({
       'An auth token with push access to dockerhub repository is required.'
     ),
   template: z
-    .enum(
-      Object.values(TEMPLATE_CONFIG).map((config) => config.template) as [
-        TemplateName,
-      ]
-    )
-    .default(TEMPLATE_CONFIG.JavaScript.template),
+    .enum(Object.keys(TEMPLATE_CONFIG) as [TemplateName])
+    .default('JavaScript'),
   sconeVersion: z.enum(['v5', 'v5.9']).default('v5'),
 });
 

--- a/api/src/singleFunction/sconifyImage.ts
+++ b/api/src/singleFunction/sconifyImage.ts
@@ -1,5 +1,5 @@
 import Docker from 'dockerode';
-import { SCONIFY_IMAGE } from '../constants/constants.js';
+import { SCONIFY_IMAGE_NAME } from '../constants/constants.js';
 import { logger } from '../utils/logger.js';
 import { inspectImage } from './inspectImage.js';
 import { pruneBuilderCache } from './pruneBuilderCache.js';
@@ -13,6 +13,7 @@ const docker = new Docker();
  */
 export async function sconifyImage({
   fromImage,
+  sconifyVersion,
   entrypoint,
   binary,
 }: {
@@ -20,6 +21,10 @@ export async function sconifyImage({
    * image to sconify
    */
   fromImage: string;
+  /**
+   * sconifier version
+   */
+  sconifyVersion: string;
   /**
    * command to run the app (whitelisted)
    */
@@ -30,14 +35,15 @@ export async function sconifyImage({
   binary: string;
 }): Promise<string> {
   logger.info({ fromImage, entrypoint }, 'Running sconify command...');
+  const sconifierImage = `${SCONIFY_IMAGE_NAME}:${sconifyVersion}`;
 
-  logger.info({ sconeImage: SCONIFY_IMAGE }, 'Pulling scone image...');
-  await pullSconeImage(SCONIFY_IMAGE);
+  logger.info({ sconifierImage }, 'Pulling sconifier image...');
+  await pullSconeImage(sconifierImage);
 
   const toImage = `${fromImage}-tmp-sconified-${Date.now()}`; // create an unique temporary identifier for the target image
   logger.info({ fromImage, toImage }, 'Sconifying...');
   const sconifyContainer = await docker.createContainer({
-    Image: SCONIFY_IMAGE,
+    Image: sconifierImage,
     Cmd: [
       'sconify_iexec',
       `--from=${fromImage}`,

--- a/cli/src/cmd/deploy.ts
+++ b/cli/src/cmd/deploy.ts
@@ -92,14 +92,19 @@ export async function deploy({ chain }: { chain?: string }) {
     spinner.start(
       'Transforming your image into a TEE image, this may take a few minutes...'
     );
-    const { dockerImage, dockerImageDigest, fingerprint, entrypoint } =
-      await sconify({
-        iAppNameToSconify: imageTag,
-        template,
-        walletAddress,
-        dockerhubAccessToken,
-        dockerhubUsername,
-      });
+    const {
+      dockerImage,
+      dockerImageDigest,
+      sconeVersion,
+      fingerprint,
+      entrypoint,
+    } = await sconify({
+      iAppNameToSconify: imageTag,
+      template,
+      walletAddress,
+      dockerhubAccessToken,
+      dockerhubUsername,
+    });
     spinner.succeed(`Pushed TEE image ${dockerImage} on dockerhub`);
 
     spinner.start('Deploying your TEE image on iExec...');
@@ -113,7 +118,7 @@ export async function deploy({ chain }: { chain?: string }) {
       // Some code sample here: https://github.com/iExecBlockchainComputing/dataprotector-sdk/blob/v2/packages/protected-data-delivery-dapp/deployment/src/singleFunction/deployApp.ts
       mrenclave: {
         framework: 'SCONE',
-        version: 'v5',
+        version: sconeVersion,
         entrypoint: entrypoint,
         heapSize: 1073741824,
         fingerprint,

--- a/cli/src/config/config.ts
+++ b/cli/src/config/config.ts
@@ -1,4 +1,5 @@
 export const SCONE_TAG = ['tee', 'scone'];
+export const DEFAULT_SCONE_VERSION = 'v5.9';
 
 export const SCONIFY_API_HTTP_URL = 'https://iapp-api.iex.ec';
 export const SCONIFY_API_WS_URL = 'wss://iapp-api.iex.ec';

--- a/cli/src/utils/sconify.ts
+++ b/cli/src/utils/sconify.ts
@@ -1,4 +1,8 @@
-import { SCONIFY_API_HTTP_URL, SCONIFY_API_WS_URL } from '../config/config.js';
+import {
+  DEFAULT_SCONE_VERSION,
+  SCONIFY_API_HTTP_URL,
+  SCONIFY_API_WS_URL,
+} from '../config/config.js';
 import { getAuthToken } from './dockerhub.js';
 import { sleep } from './sleep.js';
 import {
@@ -29,11 +33,13 @@ export async function sconify({
 }): Promise<{
   dockerImage: string;
   dockerImageDigest: string;
+  sconeVersion: string;
   fingerprint: string;
   entrypoint: string;
 }> {
   let dockerImage;
   let dockerImageDigest;
+  let sconeVersion;
   let entrypoint;
   let fingerprint;
   try {
@@ -52,8 +58,9 @@ export async function sconify({
     let sconifyResult: {
       dockerImage?: string;
       dockerImageDigest?: string;
-      fingerprint?: string;
       entrypoint?: string;
+      fingerprint?: string;
+      sconeVersion?: string;
     };
 
     if (process.env.EXPERIMENTAL_WS_API) {
@@ -125,6 +132,7 @@ export async function sconify({
                 dockerhubImageToSconify: iAppNameToSconify,
                 dockerhubPushToken: pushToken,
                 yourWalletPublicAddress: walletAddress,
+                sconeVersion: DEFAULT_SCONE_VERSION,
               })
             );
           },
@@ -144,6 +152,7 @@ export async function sconify({
           dockerhubImageToSconify: iAppNameToSconify,
           dockerhubPushToken: pushToken, // used for pushing sconified image on user repo
           yourWalletPublicAddress: walletAddress,
+          sconeVersion: DEFAULT_SCONE_VERSION,
         }),
       })
         .catch(() => {
@@ -181,14 +190,19 @@ export async function sconify({
     if (!sconifyResult.dockerImageDigest) {
       throw Error('Unexpected server response: missing dockerImageDigest');
     }
+    if (!sconifyResult.sconeVersion) {
+      throw Error('Unexpected server response: missing sconeVersion');
+    }
     if (!sconifyResult.entrypoint) {
       throw Error('Unexpected server response: missing entrypoint');
     }
     if (!sconifyResult.fingerprint) {
       throw Error('Unexpected server response: missing fingerprint');
     }
+
     dockerImage = sconifyResult.dockerImage;
     dockerImageDigest = sconifyResult.dockerImageDigest;
+    sconeVersion = sconifyResult.sconeVersion;
     entrypoint = sconifyResult.entrypoint;
     fingerprint = sconifyResult.fingerprint;
   } catch (err) {
@@ -217,6 +231,7 @@ export async function sconify({
   return {
     dockerImage,
     dockerImageDigest,
+    sconeVersion,
     entrypoint,
     fingerprint,
   };


### PR DESCRIPTION
# `iapp` support for scone v5.9

Bring support to deploy scone v5.9 iapps via the `iapp` CLI

## API changes

- endpoint `POST /sconify/build` and websocket request `SCONIFY_BUILD` now accepts an optional `sconeVersion` param (`v5` | `v5.9`, default `v5` for backward compatibility) allowing to use scone 5.7 or 5.9 for sconification
- endpoint `POST /sconify/build` and websocket request `SCONIFY_BUILD`  returns a `sconeVersion` suitable for app deployment (`app.mrenclave.version`)
- legacy endpoint `POST /sconify` and websocket request `SCONIFY` methods are renamed `deprecated_xxx` and did not receive updates (will be removed)

## iapp CLI changes

- `iapp deploy` now requests a sconify build with `"sconeVersion": "v5.9"`
- `iapp deploy` uses the `sconeVersion` returned by the API to set `app.mrenclave.version` while deploying the app

## Backward compatibility

- previous `iapp` CLI versions: the API is compatible with previous `iapp` versions, when `sconeVersion` is not specified, the sconification occurs with scone v5.7 (v5) as expected by previous `iapp` CLI versions.
- existing templates: sconification with scone 5.9 is compatible with existing templates (based on `node:14.4.0-alpine3.11` and `python:3.8.3-alpine3.10`), clients can upgrade their `iapp` CLI without breaking their existing iapp projects.
- new `iapp` CLI: :warning: the new `iapp` CLI is not compatible with previous versions of the API, this requires the API to be deployed prior to the release of `@iexec/iapp` package.