### PR TITLE
ci(cli): use npm dist tag nightly for nightly versions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -93,8 +93,7 @@ steps:
         from_secret: npm_username
       token:
         from_secret: npm_token
-      # TODO: change to nightly
-      tag: latest
+      tag: nightly
       access: public
       folder: cli
     when:


### PR DESCRIPTION
stop tagging latest on nightly to prepare first stable release