### PR TITLE
feat: Scone prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 node_modules
 api/.env
+api/sig
 .tags
 
 cli/dist

--- a/api/package.json
+++ b/api/package.json
@@ -4,9 +4,10 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "tsx --env-file=.env ./src/index.js",
-    "dev": "tsx --env-file=.env --watch ./src/index.js",
-    "dev:pretty": "tsx --env-file=.env --watch ./src/index.js | pino-pretty -tc",
+    "ensure-signing-key": "[ -e 'sig/enclave-key.pem' ] && echo 'using existing signing key' || (mkdir -p sig && openssl genrsa -3 -out sig/enclave-key.pem 3072 && echo 'generated new signing key')",
+    "start": "npm run ensure-signing-key && tsx --env-file=.env ./src/index.js",
+    "dev": "npm run ensure-signing-key && tsx --env-file=.env --watch ./src/index.js",
+    "dev:pretty": "npm run ensure-signing-key && tsx --env-file=.env --watch ./src/index.js | pino-pretty -tc",
     "check-format": "prettier --check .",
     "check-types": "tsc --project tsconfig.json",
     "format": "prettier --write .",

--- a/api/src/sconify/sconifyBuild.handler.ts
+++ b/api/src/sconify/sconifyBuild.handler.ts
@@ -28,6 +28,7 @@ const bodySchema = z.object({
     .enum(Object.keys(TEMPLATE_CONFIG) as [TemplateName])
     .default('JavaScript'),
   sconeVersion: z.enum(['v5', 'v5.9']).default('v5'),
+  sconeProd: z.boolean().default(false),
 });
 
 async function handleSconifyRequest(requestObj: object) {
@@ -36,6 +37,7 @@ async function handleSconifyRequest(requestObj: object) {
   let dockerhubPushToken: string;
   let sconeVersion: SconeVersion;
   let template: TemplateName;
+  let sconeProd: boolean;
   try {
     ({
       yourWalletPublicAddress,
@@ -43,6 +45,7 @@ async function handleSconifyRequest(requestObj: object) {
       dockerhubPushToken,
       sconeVersion,
       template,
+      sconeProd,
     } = bodySchema.parse(requestObj));
   } catch (error) {
     throw fromError(error, {
@@ -58,6 +61,7 @@ async function handleSconifyRequest(requestObj: object) {
       userWalletPublicAddress: yourWalletPublicAddress,
       sconeVersion,
       templateLanguage: template,
+      sconeProd,
     });
   return {
     dockerImage,

--- a/api/src/sconify/sconifyBuild.service.ts
+++ b/api/src/sconify/sconifyBuild.service.ts
@@ -23,6 +23,7 @@ export async function sconify({
   pushToken,
   sconeVersion,
   templateLanguage,
+  sconeProd = false,
 }: {
   /**
    * Examples of valid dockerImageToSconify:
@@ -39,6 +40,7 @@ export async function sconify({
   pushToken: string;
   templateLanguage: TemplateName;
   sconeVersion: SconeVersion;
+  sconeProd?: boolean;
 }): Promise<{
   dockerImage: string;
   dockerImageDigest: string;
@@ -58,6 +60,7 @@ export async function sconify({
       templateLanguage,
       userWalletPublicAddress,
       wsEnabled,
+      sconeProd,
     },
     'New sconify request'
   );
@@ -142,6 +145,7 @@ export async function sconify({
       sconifyVersion,
       entrypoint: appEntrypoint,
       binary: configTemplate.binary,
+      prod: sconeProd,
     });
     logger.info({ sconifiedImageId }, 'Sconified successfully');
   } finally {
@@ -168,7 +172,7 @@ export async function sconify({
 
   const imageRepo = `${dockerUserName}/${imageName}`;
   const sconifiedImageShortId = sconifiedImageId.substring(7, 7 + 12); // extract 12 first chars after the leading "sha256:"
-  const sconifiedImageTag = `${imageTag}-tee-scone-${sconifyVersion}-debug-${sconifiedImageShortId}`; // add digest in tag to avoid replacing previous build
+  const sconifiedImageTag = `${imageTag}-tee-scone-${sconifyVersion}-${sconeProd ? 'prod' : 'debug'}-${sconifiedImageShortId}`; // add digest in tag to avoid replacing previous build
   const sconifiedImage = `${imageRepo}:${sconifiedImageTag}`;
 
   let pushed;

--- a/cli/src/cmd/debug.ts
+++ b/cli/src/cmd/debug.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers';
 import { askForWallet } from '../cli-helpers/askForWallet.js';
-import { getIExecDebug } from '../utils/iexec.js';
+import { getIExec } from '../utils/iexec.js';
 import { getSpinner } from '../cli-helpers/spinner.js';
 import * as color from '../cli-helpers/color.js';
 import { handleCliError } from '../cli-helpers/handleCliError.js';
@@ -26,7 +26,7 @@ export async function debug({
     const chainConfig = getChainConfig(chainName);
     spinner.info(`Using chain ${chainName}`);
     const signer = await askForWallet({ spinner });
-    const iexec = getIExecDebug({
+    const iexec = getIExec({
       ...chainConfig,
       signer,
     });

--- a/cli/src/cmd/deploy.ts
+++ b/cli/src/cmd/deploy.ts
@@ -15,7 +15,7 @@ import { handleCliError } from '../cli-helpers/handleCliError.js';
 import { getSpinner } from '../cli-helpers/spinner.js';
 import { askForAppSecret } from '../cli-helpers/askForAppSecret.js';
 import { askForWallet } from '../cli-helpers/askForWallet.js';
-import { getIExecDebug } from '../utils/iexec.js';
+import { getIExec } from '../utils/iexec.js';
 import { goToProjectRoot } from '../cli-helpers/goToProjectRoot.js';
 import * as color from '../cli-helpers/color.js';
 import { hintBox } from '../cli-helpers/box.js';
@@ -43,7 +43,7 @@ export async function deploy({ chain }: { chain?: string }) {
     if (useTdx) {
       iexec = getIExecTdx({ ...chainConfig, signer });
     } else {
-      iexec = getIExecDebug({ ...chainConfig, signer });
+      iexec = getIExec({ ...chainConfig, signer });
     }
 
     await ensureBalances({ spinner, iexec });

--- a/cli/src/cmd/run.ts
+++ b/cli/src/cmd/run.ts
@@ -11,7 +11,7 @@ import {
 import { addRunData } from '../utils/cacheExecutions.js';
 import { getSpinner, type Spinner } from '../cli-helpers/spinner.js';
 import { handleCliError } from '../cli-helpers/handleCliError.js';
-import { getIExecDebug } from '../utils/iexec.js';
+import { getIExec } from '../utils/iexec.js';
 import { extractZipToFolder } from '../utils/extractZipToFolder.js';
 import { askShowResult } from '../cli-helpers/askShowResult.js';
 import { goToProjectRoot } from '../cli-helpers/goToProjectRoot.js';
@@ -104,7 +104,7 @@ export async function runInDebug({
   if (useTdx) {
     iexec = getIExecTdx({ ...chainConfig, signer });
   } else {
-    iexec = getIExecDebug({
+    iexec = getIExec({
       ...chainConfig,
       signer,
     });
@@ -151,7 +151,7 @@ export async function runInDebug({
   // Workerpool Order
   spinner.start('Fetching workerpool order...');
   const workerpoolOrderbook = await iexec.orderbook.fetchWorkerpoolOrderbook({
-    workerpool: useTdx ? WORKERPOOL_TDX : chainConfig.workerpoolDebug,
+    workerpool: useTdx ? WORKERPOOL_TDX : chainConfig.workerpool,
     app: iAppAddress,
     dataset: protectedData || ethers.ZeroAddress,
     minTag: SCONE_TAG,

--- a/cli/src/config/config.ts
+++ b/cli/src/config/config.ts
@@ -3,8 +3,12 @@ import { useExperimentalNetworks } from '../utils/featureFlags.js';
 export const SCONE_TAG = ['tee', 'scone'];
 export const DEFAULT_SCONE_VERSION = 'v5.9';
 
-export const SCONIFY_API_HTTP_URL = 'https://iapp-api.iex.ec';
-export const SCONIFY_API_WS_URL = 'wss://iapp-api.iex.ec';
+// export const SCONIFY_API_HTTP_URL = 'https://iapp-api.iex.ec';
+// export const SCONIFY_API_WS_URL = 'wss://iapp-api.iex.ec';
+
+// TODO use local server for the POC
+export const SCONIFY_API_HTTP_URL = 'http://127.0.0.1:3000';
+export const SCONIFY_API_WS_URL = 'ws://127.0.0.1:3000';
 
 export const CONFIG_FILE = 'iapp.config.json';
 export const TEST_INPUT_DIR = 'input';
@@ -71,10 +75,9 @@ export const WS_RECONNECTION_MAX_ATTEMPTS = Math.floor(
 
 type ChainConfig = {
   rpcHostUrl: string;
-  smsDebugUrl: string;
   ipfsGatewayUrl: string;
   iexecExplorerUrl: string;
-  workerpoolDebug: string;
+  workerpool: string;
 };
 
 export const DEFAULT_CHAIN = 'bellecour';
@@ -82,25 +85,22 @@ export const DEFAULT_CHAIN = 'bellecour';
 export const CHAINS_CONFIGURATIONS: Record<string, ChainConfig> = {
   bellecour: {
     rpcHostUrl: 'https://bellecour.iex.ec',
-    smsDebugUrl: 'https://sms.scone-debug.v8-bellecour.iex.ec',
     ipfsGatewayUrl: 'https://ipfs-gateway.v8-bellecour.iex.ec',
     iexecExplorerUrl: 'https://explorer.iex.ec/bellecour',
-    workerpoolDebug: 'debug-v8-learn.main.pools.iexec.eth',
+    workerpool: 'prod-v8-learn.main.pools.iexec.eth',
   },
   'arbitrum-mainnet': {
     rpcHostUrl: 'https://arb1.arbitrum.io/rpc',
-    smsDebugUrl: 'https://sms-debug.arbitrum-mainnet.iex.ec',
     ipfsGatewayUrl: 'https://ipfs-gateway.arbitrum-mainnet.iex.ec',
     iexecExplorerUrl: 'https://explorer.iex.ec/arbitrum-mainnet',
-    workerpoolDebug: '0xAaA90d37034fD1ea27D5eF2879f217fB6fD7F7Ca',
+    workerpool: '0x2c06263943180cc024daffeee15612db6e5fd248',
   },
   ...(useExperimentalNetworks && {
     'arbitrum-sepolia-testnet': {
       rpcHostUrl: 'https://sepolia-rollup.arbitrum.io/rpc',
-      smsDebugUrl: 'https://sms.arbitrum-sepolia-testnet.iex.ec',
       ipfsGatewayUrl: 'https://ipfs-gateway.arbitrum-sepolia-testnet.iex.ec',
       iexecExplorerUrl: 'https://explorer.iex.ec/arbitrum-sepolia-testnet',
-      workerpoolDebug: '0xB967057a21dc6A66A29721d96b8Aa7454B7c383F',
+      workerpool: '0xB967057a21dc6A66A29721d96b8Aa7454B7c383F',
     },
   }),
 };

--- a/cli/src/utils/iexec.ts
+++ b/cli/src/utils/iexec.ts
@@ -3,21 +3,18 @@ import { AbstractSigner } from 'ethers';
 import { IExec } from 'iexec';
 import { useExperimentalNetworks } from './featureFlags.js';
 
-export function getIExecDebug({
+export function getIExec({
   signer,
   rpcHostUrl,
-  smsDebugUrl,
 }: {
   signer: AbstractSigner;
   rpcHostUrl: string;
-  smsDebugUrl: string;
 }): IExec {
   return new IExec(
     {
       ethProvider: signer.connect(new JsonRpcProvider(rpcHostUrl)),
     },
     {
-      smsURL: smsDebugUrl,
       allowExperimentalNetworks: useExperimentalNetworks,
     }
   );

--- a/cli/src/utils/sconify.ts
+++ b/cli/src/utils/sconify.ts
@@ -134,6 +134,7 @@ export async function sconify({
                 dockerhubPushToken: pushToken,
                 yourWalletPublicAddress: walletAddress,
                 sconeVersion: DEFAULT_SCONE_VERSION,
+                sconeProd: true,
               })
             );
           },
@@ -154,6 +155,7 @@ export async function sconify({
           dockerhubPushToken: pushToken, // used for pushing sconified image on user repo
           yourWalletPublicAddress: walletAddress,
           sconeVersion: DEFAULT_SCONE_VERSION,
+          sconeProd: true,
         }),
       })
         .catch(() => {


### PR DESCRIPTION
# PoC `iapp` x Scone production

This poc demonstrates how `iapp` can [create](https://explorer.iex.ec/bellecour/app/0x690cfdcf063546a11331dae5c6946b95376052a2) and [run](https://explorer.iex.ec/bellecour/deal/0xcadb8a9aff4238638d1f064bc882140fdbb7730532570aca2de6259f3ae4ea4d) Scone production app instead of Scone debug apps.
This allows the builder to create production-ready apps without extra steps.

## PoC usage

clone this branch and follow the instructions

```sh
git clone git@github.com:iExecBlockchainComputing/iapp.git
cd iapp
git checkout poc-scone-prod
```

### Run the server locally

NB: the server is intended to run on a Linux host

```sh
cd api
```

prepare `.env` file

```sh
cp .env.template .env
```
:point_right: edit `.env` and fill in Scotain registry credentials `SCONTAIN_REGISTRY_USERNAME=...` and `SCONTAIN_REGISTRY_PASSWORD=...`

Install dependencies and run the server

```sh
npm ci
npm run start
```
The sconification server starts on port 3000 with an autogenerated signing key (if no one already exists)

### Install the CLI

```sh
cd cli
npm ci
npm run build
npm i -g .
```
the CLI `iapp` is now installed

this version notabliy:
- use the server running on port 3000 instead of the official server
- use the prod SMS instead of the debug
- use a prod workerpools instead of a debug one

### Creating and running Scone prod iapps

Ensure the server is running and use the installed CLI as any previous version of `iapp`

- `iapp init`
- `iapp test`
- `iapp deploy` (uses local Scone prod API + prod SMS)
- `iapp run <address>` (uses prod SMS + prod workerpool)

Examples:
- [Deployed iapp](https://explorer.iex.ec/bellecour/app/0x690cfdcf063546a11331dae5c6946b95376052a2)
- [Task running on prod workerpool](https://explorer.iex.ec/bellecour/task/0xffcc89f9e05a482942d16343450f2eac9781e2b9e8905462f38860a08991ed64)