### PR TITLE
feat: support iapp debug on arbitrum-sepolia

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -16,7 +16,7 @@
         "dockerode": "^4.0.5",
         "ethers": "^6.13.5",
         "figlet": "^1.8.1",
-        "iexec": "^8.16.1",
+        "iexec": "^8.17.0",
         "jszip": "^3.10.1",
         "magic-bytes.js": "^1.10.0",
         "msgpackr": "^1.11.2",
@@ -3044,9 +3044,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/iexec": {
-      "version": "8.16.1",
-      "resolved": "https://registry.npmjs.org/iexec/-/iexec-8.16.1.tgz",
-      "integrity": "sha512-0Kxt5z2gpjcwRkGmfr3/ckOk1G3p6G4s4CQzjtgKo8v64giLneO/PcbQAkRLW7imCNegvQL6Bpw1oQCwELYHqw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/iexec/-/iexec-8.17.0.tgz",
+      "integrity": "sha512-wOXtQenIpXa94DA12CqvFXsRlje5U1eG4NQJwwEm5BxEMG5mZqEI8etHcUx8/qy1WQwwbuv1CcPP07gT8GZI3Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ensdomains/ens-contracts": "^1.2.5",

--- a/cli/package.json
+++ b/cli/package.json
@@ -40,7 +40,7 @@
     "dockerode": "^4.0.5",
     "ethers": "^6.13.5",
     "figlet": "^1.8.1",
-    "iexec": "^8.16.1",
+    "iexec": "^8.17.0",
     "jszip": "^3.10.1",
     "magic-bytes.js": "^1.10.0",
     "msgpackr": "^1.11.2",


### PR DESCRIPTION
This PR enables `iapp debug` via workerpool API resolution from Compass (support added in `iexec@8.17.0`)

example:
```
$ EXPERIMENTAL_NETWORKS=1 iapp debug 0xdcda174e164e6f10d8de447c5db95c49b95a12397c494714ff5204c67bef4c33 --chain arbitrum-sepolia-testnet
EXPERIMENTAL_NETWORKS enabled
ℹ Using chain arbitrum-sepolia-testnet
Using wallet ******************
✔ Enter the password to unlock your wallet ***********************************

Worker: 0x2922ec0f059e34753f594a20e96188157c360034

[STDOUT]
Received 0 args
It seems there is an issue with your protected data: Error: Failed to load protected data
    at file:///app/node_modules/@iexec/dataprotector-deserializer/dist/esm/index.js:83:23


[STDERR]
[SCONE|DEBUG] tools/libsgx/src/platform.c:199:platform_detect_sgx_driver(): found driver /dev/sgx/enclave
[SCONE|DEBUG] tools/libsgx/src/platform.c:199:platform_detect_sgx_driver(): found driver /dev/sgx/enclave
[SCONE|DEBUG] tools/libsgx/src/layout.c:861:scone_enclave_create_layout(): Enclave Size:		1319 MiB (Code, Data, Stack, Heap, ...)
[SCONE|DEBUG] tools/libsgx/src/layout.c:862:scone_enclave_create_layout(): Enclave Memory Region Size:	2048 MiB (SGX enforces power of two)
[SCONE|DEBUG] tools/libsgx/src/builder.c:918:finalize_builder(): enclave base: 0x1000000000 
[SCONE|DEBUG] tools/libsgx/src/layout.c:861:scone_enclave_create_layout(): Enclave Size:		1319 MiB (Code, Data, Stack, Heap, ...)
[SCONE|DEBUG] tools/libsgx/src/layout.c:862:scone_enclave_create_layout(): Enclave Memory Region Size:	2048 MiB (SGX enforces power of two)
[SCONE|DEBUG] eai::client::cas_client::name_resolution rust-crates/eai/src/client/cas_client/name_resolution.rs:181:CAS address azubsmsbp-sms-prod-bubble.public.az1.internal:18765 resolved to 1 socket address(es)
[SCONE|DEBUG] eai::client::cas_client::connection rust-crates/eai/src/client/cas_client/connection.rs:125:Establishing connection to '10.1.0.5:18765' ...
[SCONE|DEBUG] rustls::client::hs rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/hs.rs:80:No cached session for DnsName("azubsmsbp-sms-prod-bubble.public.az1.internal")
[SCONE|DEBUG] rustls::client::hs rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/hs.rs:138:Not resuming any session
[SCONE|DEBUG] rustls::client::hs rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/hs.rs:781:Using ciphersuite TLS13_AES_256_GCM_SHA384
[SCONE|DEBUG] rustls::client::tls13 rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/tls13.rs:142:Not resuming
[SCONE|DEBUG] rustls::client::tls13 rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/tls13.rs:419:TLS1.3 encrypted extensions: [Protocols([ProtocolName(53434f4e452d39)]), ServerNameAck]
[SCONE|DEBUG] rustls::client::hs rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/hs.rs:638:ALPN protocol is Some(b"SCONE-9")
[SCONE|DEBUG] rustls::client::tls13 rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/tls13.rs:798:Got CertificateRequest CertificateRequestPayloadTls13 { context: , extensions: [SignatureAlgorithms([ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256])] }
[SCONE|DEBUG] rustls::client::common rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/common.rs:99:Attempting client auth
[SCONE|DEBUG] eai::client::cas_client::singleton rust-crates/eai/src/client/cas_client/singleton.rs:89:Established TLS connection to CAS, ALPN protocol version: 9
[SCONE|DEBUG] eai::client::cas_client::singleton rust-crates/eai/src/client/cas_client/singleton.rs:126:Sending Singleton Page request message to CAS (client protocol version range: [2,18])
[SCONE|INFO] src/enclave/dispatch.c:118:initialize_logging(): Logging level set to DEBUG due to variable SCONE_LOG from untrusted environment
[SCONE] Using the following values (default values or specified in the untrusted environment):

SCONE_QUEUES=2
SCONE_SLOTS=256
SCONE_SIGPIPE=0
SCONE_MMAP32BIT=0
SCONE_SSPINS=100
SCONE_SSLEEP=4000
SCONE_CONFIG=autogenerated
SCONE_TCS=8
SCONE_LOG=DEBUG
SCONE_HEAP=1073741824
SCONE_STACK=1048576
SCONE_ESPINS=10000
SCONE_MODE=hw
SCONE_ALLOW_DLOPEN=yes (protected)
SCONE_MPROTECT=no
SCONE_FORK=no
SCONE_FORK_OS=0
SCONE_EXTENSIONS_PATH=/lib/libbinary-fs.so
SCONE_CONFIG_ID: RR1owWmEzf00000xdcda174e164e6f10d8de447c5db95c49b95a12397c494714ff5204c67bef4c33/app

musl version: 1.2.5
SCONE version: 5.9.0-1-g6d6d73ec2-iExec-5.9.0 (base: 2c13f547) (2025-02-19 09:41:57)
Enclave hash: 89829276a3f117765010c482ce20ae1e65839f88a6cb306eaf4860a38d16eca8
The runtime is locked to CAS with key(s) 2xDoXtFbueQu5Bvv3gWPvowU5g2fEs9uX3xtsTXjGpcBfocXCE, 3vks9cySbhaeuhk3MWuaEPgNfMgPNctdnRgQg24Ao27tv23cYC, 4MNv2bq2XHcYZwKGbyiday9D6dweuoaUVDmgWsdh1tGii9K8wu, 41p6E8LM2CTcdiTqKZDxzqYgvAHjyFcBmCfj9zFXXEi8PcW5cU, 3vT7YytAL7MrhtXGK9PvxQtRhck7bD3SJMLEu4i8L6yhAjueom, 4f1EayZv4z5yL8B97D4MWr6EV2G52bAkXDFMPPLpAS8jT2Pzzm, 4bQgczAX769sm5WkMGe8DsFZTdV4p9kpLwrsCspWxMy8AfcpK6, 3rDKTqDJJZbtr7GHG47P1AmquP2Cup9tLZMiaX6HwpjEvTypNz, 48Wu4XZmJgqVzCSYUVEmYF1JS8zngUEqsSRRGmE1B9DB2DV8ZT, 4SYzND6cNfQDSUT9LUvczbTTVRW9aNnJmq1MCnjYndNF2XDkoq, 3Z9PzYEyXTgxQ1YRZeSK1KhssNVTWz28MHfrdoCNyERCDwk74o, 35PmAAeYmv54CWKD27A89QPfXvjJev6vLPmPtUmnexDt9wZGwE, 4JDknLAxuX8j6mak8vapwKWkAXPs2UyjNETdpXoCyigz5ma2C3, 3RvYRdnCLGsCrFBAc2BYJP6p439LLPw7wk3nuuTN3qLNnBKPpW, 4oaRZfkw3Wwb4rVPbKF7PUZNHXo4KgENXPyiRjUPn79MoCEBfb, 4dSY1nNTUSonGuSgPoPrquTo7f3MDLfuuk4qboD3b6zUktPsTj, 4QjnxbxNGJp3ZKNnYz7fw7vvUXgUDAJtewwvdGH8kg7ZGQnoSa, 3yJEHm5BF2Za1cvLoRvsS5iUMn7LjNxAp6u5DcZbDnxh4DoNFC, 3NuDY5E3kxkZZmH5svTftcG8CYwawf3sQUYcH5wb4VomUveNAd, 4E3RuA3yHEhhPq8cZgFBdfJcWLXevsRaoDzoMCoF1jCJmD3aY3
[SCONE|WARN] src/enclave/dispatch.c:158:print_runtime_info(): Application runs in SGX debug mode. Its memory can be read from outside the enclave with a debugger! This is not secure!
[SCONE|DEBUG] src/enclave/dispatch.c:200:print_runtime_info(): Context switch mode: native
[SCONE|DEBUG] src/enclave/dispatch.c:225:print_runtime_info(): fsgsbase support available, with OS support
[SCONE|DEBUG] src/enclave/dispatch.c:238:print_runtime_info(): CPU features enabled in xfrm [231]: x87, SSE, AVX, AVX-512 opmask, AVX-512 Hi256, AVX-512 ZMM_Hi256. xstate size: 2688B
[SCONE|DEBUG] src/enclave/dispatch.c:255:print_runtime_info(): glibc mode: 0
[SCONE|INFO] scone_rrt::implementation::ffi rust-crates/scone_rrt/src/implementation/ffi.rs:517:Heuristic memory overcomitting is activated
[SCONE|INFO] scone_rrt::implementation::shielding::file_descriptor rust-crates/scone_rrt/src/implementation/shielding/file_descriptor.rs:123:Collected 4 pre-existing file descriptors
[SCONE|DEBUG] scone_rrt::implementation::state rust-crates/scone_rrt/src/implementation/state.rs:234:Initializing enclave state either from vault file or via remote attestation
[SCONE|WARN] scone_rrt::implementation::eai rust-crates/scone_rrt/src/implementation/eai.rs:129:Insecure configuration that activates dynamic loading without singleton enclave!
[SCONE|DEBUG] scone_rrt::implementation::eai rust-crates/scone_rrt/src/implementation/eai.rs:149:Attesting with Service ID RR1owWmEzf00000xdcda174e164e6f10d8de447c5db95c49b95a12397c494714ff5204c67bef4c33/app at CAS azubsmsbp-sms-prod-bubble.public.az1.internal:18765
[SCONE|DEBUG] eai::client::las_client rust-crates/eai/src/client/las_client.rs:223:Establishing connection to LAS at iexec-las-0x2922ec0f059e34753f594a20e96188157c360034-a997e44e00:18766 waiting at most 45s for connection to establish
[SCONE|DEBUG] eai::client::las_client rust-crates/eai/src/client/las_client.rs:264:Resolved LAS address to 172.240.2.4:18766
[SCONE|DEBUG] eai::client::las_client rust-crates/eai/src/client/las_client.rs:382:Received LasHello message, LAS version 5.9.0-1-gff3b5ed35-5.9.1 (base: 2c13f547) (2025-02-06 07:58:40), protocol version range [0,18]
[SCONE|DEBUG] eai::client::las_client rust-crates/eai/src/client/las_client.rs:391:Connected with LAS protocol v18
[SCONE|DEBUG] eai::client::las_client rust-crates/eai/src/client/las_client.rs:504:LAS offers these quoting mechanisms: SCONE: true EPID: false DCAP: true
[SCONE|DEBUG] scone_rrt::implementation::eai rust-crates/scone_rrt/src/implementation/eai.rs:219:Using SCONE LAS at iexec-las-0x2922ec0f059e34753f594a20e96188157c360034-a997e44e00:18766 for attestation
[SCONE|DEBUG] eai::client::cas_client::name_resolution rust-crates/eai/src/client/cas_client/name_resolution.rs:181:CAS address azubsmsbp-sms-prod-bubble.public.az1.internal:18765 resolved to 1 socket address(es)
[SCONE|DEBUG] eai::client::cas_client rust-crates/eai/src/client/cas_client.rs:178:Client identity generated: 335iMcy5gqQxJdkYKrvyoX9jb1NcjSQfvjSXNfWqKeFsCVbVMg
[SCONE|DEBUG] eai::client::cas_client::connection rust-crates/eai/src/client/cas_client/connection.rs:125:Establishing connection to '10.1.0.5:18765' ...
[SCONE|DEBUG] rustls::client::hs rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/hs.rs:80:No cached session for DnsName("azubsmsbp-sms-prod-bubble.public.az1.internal")
[SCONE|DEBUG] rustls::client::hs rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/hs.rs:138:Not resuming any session
[SCONE|DEBUG] rustls::client::hs rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/hs.rs:781:Using ciphersuite TLS13_AES_256_GCM_SHA384
[SCONE|DEBUG] rustls::client::tls13 rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/tls13.rs:142:Not resuming
[SCONE|DEBUG] rustls::client::tls13 rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/tls13.rs:419:TLS1.3 encrypted extensions: [Protocols([ProtocolName(53434f4e452d39)]), ServerNameAck]
[SCONE|DEBUG] rustls::client::hs rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/hs.rs:638:ALPN protocol is Some(b"SCONE-9")
[SCONE|DEBUG] rustls::client::tls13 rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/tls13.rs:798:Got CertificateRequest CertificateRequestPayloadTls13 { context: , extensions: [SignatureAlgorithms([ECDSA_NISTP384_SHA384, ECDSA_NISTP256_SHA256, ED25519, RSA_PSS_SHA512, RSA_PSS_SHA384, RSA_PSS_SHA256, RSA_PKCS1_SHA512, RSA_PKCS1_SHA384, RSA_PKCS1_SHA256])] }
[SCONE|DEBUG] rustls::client::common rust-cache/cargo/registry/src/index.crates.io-6f17d22bba15001f/rustls-0.23.12/src/client/common.rs:99:Attempting client auth
[SCONE|DEBUG] eai::client::cas_client rust-crates/eai/src/client/cas_client.rs:187:Established TLS connection to CAS, ALPN protocol version: 9
[SCONE|DEBUG] eai::client::cas_client::attestation::initial rust-crates/eai/src/client/cas_client/attestation/initial.rs:105:Available attestation collaterals: ["SCONE quote", "DCAP quote"]
[SCONE|DEBUG] eai::client::cas_client::attestation::initial rust-crates/eai/src/client/cas_client/attestation/initial.rs:160:Sending EnclaveHello message to CAS (client protocol version range: [2,18])
[SCONE|DEBUG] eai::client::cas_client rust-crates/eai/src/client/cas_client.rs:568:CAS version: 5.9.0-1-gff3b5ed35-5.9.1 (base: 2c13f547) (2025-02-06 07:58:40), LAS version: 5.9.0-1-gff3b5ed35-5.9.1 (base: 2c13f547) (2025-02-06 07:58:40), SCONE runtime version: 5.9.0-1-g6d6d73ec2-iExec-5.9.0 (base: 2c13f547) (2025-02-19 09:41:57)
[SCONE|DEBUG] eai::client::cas_client::enclave_config rust-crates/eai/src/client/cas_client/enclave_config.rs:239:Received config from CAS - server protocol version range: [2,18]
[SCONE|DEBUG] eai::client::cas_client::enclave_config rust-crates/eai/src/client/cas_client/enclave_config.rs:508:Requesting key for FSPF at '/iexec_in/volume.fspf' (genesis)
[SCONE|DEBUG] eai::client::cas_client::enclave_config rust-crates/eai/src/client/cas_client/enclave_config.rs:573:Received key for FSPF at '/iexec_in/volume.fspf'
[SCONE|DEBUG] eai::client::cas_client::enclave_config rust-crates/eai/src/client/cas_client/enclave_config.rs:508:Requesting key for FSPF at '/iexec_out/volume.fspf' (genesis)
[SCONE|DEBUG] eai::client::cas_client::enclave_config rust-crates/eai/src/client/cas_client/enclave_config.rs:573:Received key for FSPF at '/iexec_out/volume.fspf'
[SCONE|DEBUG] scone_rrt::implementation::eai rust-crates/scone_rrt/src/implementation/eai.rs:267:Successfully attested at CAS
[SCONE|DEBUG] scone_rrt::implementation::state rust-crates/scone_rrt/src/implementation/state.rs:328:The CAS is the enclave's trust store
[SCONE|DEBUG] scone_rrt::implementation::state rust-crates/scone_rrt/src/implementation/state.rs:349:Initialized enclave state
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: membarrier, number 324 is not supported
[SCONE|DEBUG] scone_rrt::implementation::state::keep_alive rust-crates/scone_rrt/src/implementation/state/keep_alive.rs:14:CAS connection keep-alive thread started
[SCONE|INFO] scone_rrt::implementation::metrics rust-crates/scone_rrt/src/implementation/metrics.rs:177:SCONE_METRICS environment variable is not set: won't activate metrics monitoring
[SCONE|INFO] src/process/init.c:186:__scone_apply_secure_config(): Updating logging level according to trusted configuration.
	Note that this will revert to the default logging level if the logging level is not configured.
[SCONE|WARN] src/process/init.c:332:__scone_apply_secure_config(): Ignoring `SCONE_PWD` environment variable and host provided process working directory.
	Applying process working directory from service's session configuration (/)
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: capget, number 125 is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: capget, number 125 is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: capget, number 125 is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: capget, number 125 is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: capget, number 125 is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: capget, number 125 is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: capget, number 125 is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: capget, number 125 is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: capget, number 125 is not supported
[SCONE|WARN] src/shielding/fs_proc.c:533:proc_fs_open(): open: /proc/version_signature is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: io_uring_setup, number 425 is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: io_uring_setup, number 425 is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: io_uring_setup, number 425 is not supported
[SCONE|WARN] src/shielding/fs_proc.c:533:proc_fs_open(): open: /proc/1/cgroup is not supported
[SCONE|WARN] src/shielding/fs_proc.c:533:proc_fs_open(): open: /proc/1/maps is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: capget, number 125 is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: capget, number 125 is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: capget, number 125 is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: capget, number 125 is not supported
[SCONE|WARN] src/syscall/syscall.c:31:__scone_ni_syscall(): system call: statx, number 332 is not supported

✔ Task logs retrieved successfully.
```