### PR TITLE
fix(js-template): fix memory exhaustion when using wasm

### DIFF
--- a/cli/templates/JavaScript/Dockerfile
+++ b/cli/templates/JavaScript/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci
 COPY . .
-ENTRYPOINT ["node", "/app/src/app.js"]
+ENTRYPOINT ["node", "--disable-wasm-trap-handler", "/app/src/app.js"]


### PR DESCRIPTION
by default nodejs allocates 10G virtual memory when creating wasm modules, this memory allocation breaks the enclave limit. node's default behavior is disabled by setting the `--disable-wasm-trap-handler` option.