### PR TITLE
feat: add support for arbitrum-mainnet

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,7 +12,7 @@
         "dockerode": "^4.0.5",
         "ethers": "^6.13.5",
         "express": "^5.1.0",
-        "iexec": "^8.15.0",
+        "iexec": "^8.18.0",
         "jwt-decode": "^4.0.0",
         "msgpackr": "^1.11.2",
         "pino": "^9.6.0",
@@ -3913,9 +3913,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/iexec": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/iexec/-/iexec-8.15.0.tgz",
-      "integrity": "sha512-aU11SU6vn4QgPb2oZ3o+DkhOW9f7pRgxOYxmbpWdTdjcqHTCKmVLi0LRpMeQfXkdDlAVCnYssIOynNARpPFYuQ==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/iexec/-/iexec-8.18.0.tgz",
+      "integrity": "sha512-lj2La67p0IKyCHhpV4F2SZD7kmE1AFhGmD26jf8si7/sTelrXun3wNTun6WAOEO9uMi49J0AlA6MxUNBxuCflg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ensdomains/ens-contracts": "^1.2.5",

--- a/api/package.json
+++ b/api/package.json
@@ -17,7 +17,7 @@
     "dockerode": "^4.0.5",
     "ethers": "^6.13.5",
     "express": "^5.1.0",
-    "iexec": "^8.15.0",
+    "iexec": "^8.18.0",
     "jwt-decode": "^4.0.0",
     "msgpackr": "^1.11.2",
     "pino": "^9.6.0",

--- a/api/src/constants/constants.ts
+++ b/api/src/constants/constants.ts
@@ -14,7 +14,7 @@ export type SconeVersion = 'v5' | 'v5.9';
 
 export const SCONIFY_IMAGE_VERSIONS: Record<SconeVersion, string> = {
   v5: '5.7.6-v15',
-  'v5.9': '5.9.0-v15',
+  'v5.9': '5.9.1-v16',
 };
 
 // This SCONIFY_IMAGE depends on Linux alpine:3.15

--- a/cli/README.md
+++ b/cli/README.md
@@ -109,10 +109,12 @@ Description: Deploy your iApp on the iExec protocol in debug mode.
 
 Options:
 
-- use `--chain` Specify the blockchain on which the iApp will be deployed (overrides defaultChain configuration which is `bellecour`). Possible values are `bellecour|arbitrum-sepolia-testnet|arbitrum-mainnet`
+- use `--chain` Specify the blockchain on which the iApp will be deployed
+  (overrides defaultChain configuration which is `bellecour`). Possible values
+  are `bellecour|arbitrum-sepolia-testnet|arbitrum-mainnet`
 
-> [!IMPORTANT]
-> To use a chain other than `bellecour`, you must pass (or set in your system) `EXPERIMENTAL_NETWORKS=true` before the `iApp` command.
+> [!IMPORTANT] To use a chain other than `bellecour`, you must pass (or set in
+> your system) `EXPERIMENTAL_NETWORKS=true` before the `iApp` command.
 
 ---
 
@@ -142,10 +144,12 @@ Options:
   [protected data](https://protocol.docs.iex.ec/for-developers/technical-references/application-io#protected-data),
   include the `--protectedData` option followed by the address of the protected
   data.
-- use `--chain` Specify the blockchain on which the iApp will be deployed (overrides defaultChain configuration which is `bellecour`). Possible values are `bellecour|arbitrum-sepolia-testnet|arbitrum-mainnet`
+- use `--chain` Specify the blockchain on which the iApp will be deployed
+  (overrides defaultChain configuration which is `bellecour`). Possible values
+  are `bellecour|arbitrum-sepolia-testnet|arbitrum-mainnet`
 
-> [!IMPORTANT]
-> To use a chain other than `bellecour`, you must pass (or set in your system) `EXPERIMENTAL_NETWORKS=true` before the `iApp` command.
+> [!IMPORTANT] To use a chain other than `bellecour`, you must pass (or set in
+> your system) `EXPERIMENTAL_NETWORKS=true` before the `iApp` command.
 
 ---
 
@@ -157,7 +161,8 @@ Command:
 iapp debug <taskId>
 ```
 
-Description: Retrieve detailed execution logs from worker nodes for a specific task.
+Description: Retrieve detailed execution logs from worker nodes for a specific
+task.
 
 ---
 
@@ -183,7 +188,7 @@ iapp wallet <action>
 
 Description: Manage wallet.
 
-Options for  `<action>` :
+Options for `<action>` :
 
 - `import` import a new wallet by providing a private key.
 - `select` select a wallet from your personnal keystore.

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -16,7 +16,7 @@
         "dockerode": "^4.0.5",
         "ethers": "^6.13.5",
         "figlet": "^1.8.1",
-        "iexec": "^8.17.1",
+        "iexec": "^8.18.0",
         "jszip": "^3.10.1",
         "magic-bytes.js": "^1.10.0",
         "msgpackr": "^1.11.2",
@@ -3044,9 +3044,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/iexec": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/iexec/-/iexec-8.17.1.tgz",
-      "integrity": "sha512-S6TZM6gZVn2qAd5spz3LOAPehQrpRsbrX/MsPVzvNHdE94c3FKptQ5o6vGwMIoL3soTLkhJPax7VM5EmH07wZA==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/iexec/-/iexec-8.18.0.tgz",
+      "integrity": "sha512-lj2La67p0IKyCHhpV4F2SZD7kmE1AFhGmD26jf8si7/sTelrXun3wNTun6WAOEO9uMi49J0AlA6MxUNBxuCflg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ensdomains/ens-contracts": "^1.2.5",

--- a/cli/package.json
+++ b/cli/package.json
@@ -40,7 +40,7 @@
     "dockerode": "^4.0.5",
     "ethers": "^6.13.5",
     "figlet": "^1.8.1",
-    "iexec": "^8.17.1",
+    "iexec": "^8.18.0",
     "jszip": "^3.10.1",
     "magic-bytes.js": "^1.10.0",
     "msgpackr": "^1.11.2",

--- a/cli/src/config/config.ts
+++ b/cli/src/config/config.ts
@@ -87,6 +87,13 @@ export const CHAINS_CONFIGURATIONS: Record<string, ChainConfig> = {
     iexecExplorerUrl: 'https://explorer.iex.ec/bellecour',
     workerpoolDebug: 'debug-v8-learn.main.pools.iexec.eth',
   },
+  'arbitrum-mainnet': {
+    rpcHostUrl: 'https://arb1.arbitrum.io/rpc',
+    smsDebugUrl: 'https://sms-debug.arbitrum-mainnet.iex.ec',
+    ipfsGatewayUrl: 'https://ipfs-gateway.arbitrum-mainnet.iex.ec',
+    iexecExplorerUrl: 'https://explorer.iex.ec/arbitrum-mainnet',
+    workerpoolDebug: '0xAaA90d37034fD1ea27D5eF2879f217fB6fD7F7Ca'
+  },
   ...(useExperimentalNetworks && {
     'arbitrum-sepolia-testnet': {
       rpcHostUrl: 'https://sepolia-rollup.arbitrum.io/rpc',


### PR DESCRIPTION
Draft PR to prepare `arbitrum-mainnet` chain addition

TODO:
- [x] wait for `iexec` release https://github.com/iExecBlockchainComputing/iexec-sdk/pull/460 and update `iexec` package
- [x] set arbitrum-mainnet debug workerpool address
- [x] wait for all services to be running on arbitrum-mainnet 
  - [x] https://sms-debug.arbitrum-mainnet.iex.ec
  - [x] https://ipfs-gateway.arbitrum-mainnet.iex.ec
  - [ ] https://explorer.iex.ec/arbitrum-mainnet