### PR TITLE
feat: migrate to Scone prod

### DIFF
--- a/.github/workflows/reusable-api-deploy.yml
+++ b/.github/workflows/reusable-api-deploy.yml
@@ -58,6 +58,27 @@ jobs:
           fi
         shell: bash
 
+      - name: Check configuration files on server
+        run: |
+          ssh -o StrictHostKeyChecking=no \
+              -i ~/.ssh/ghrunnerci \
+              ${{ secrets.host }} << 'EOF'
+            cd /opt/iapp-api
+            missing=0
+            if [ ! -f .env.app ]; then
+              echo ".env.app file not found on remote server"
+              missing=1
+            fi
+            if [ ! -f sig/enclave-key.pem ]; then
+              echo "sig/enclave-key.pem not found on remote server"
+              missing=1
+            fi
+            if [ "$missing" -ne 0 ]; then
+              exit 1
+            fi
+          EOF
+        shell: bash
+
       - name: Prepare .env for Compose
         run: |
           printf "IMAGE_NAME=%s\nIMAGE_TAG=%s\n" "${{ env.IMAGE_NAME }}" "${{ inputs.tag }}"> .env

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 node_modules
 api/.env
+api/sig
 .tags
 
 cli/dist

--- a/api/README.md
+++ b/api/README.md
@@ -29,14 +29,27 @@ The API is composed of:
 - Node 20
 - docker installed locally with support for linux/amd64 architecture (either
   native or emulated)
-- Scontain account whit pull access to docker repository
+- Scontain account with pull access to docker repository
   `registry.scontain.com/scone-production/iexec-sconify-image`
+- An enclave signing key to sign Scone production images
 
 Create a `.env` file see [`.env.template`](.env.template)
 
 ```sh
 cp .env.template .env
 # fill in the .env file
+```
+
+Create or provide your own enclave signing key in `sig/enclave-key.pem` to sign
+Scone production images
+
+> The enclave signing key should be a PEM formatted RSA key 3072 bits
+>
+> A valid signing key can be generated with openssl by running
+> `openssl genrsa -3 3072`
+
+```sh
+npm run ensure-signing-key
 ```
 
 ## run locally

--- a/api/docker-compose.yml
+++ b/api/docker-compose.yml
@@ -8,7 +8,9 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       # .env.app already on the server
-      - ./.env.app:/app/.env
+      - ./.env.app:/app/.env:ro
+      # enclave key already on the server in sig/enclave-key.pem
+      - ./sig/:/app/sig/:ro
     healthcheck:
       test: ['CMD', 'curl', '-f', 'http://localhost:3000/health']
       interval: 30s

--- a/api/package.json
+++ b/api/package.json
@@ -4,9 +4,10 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "start": "tsx --env-file=.env ./src/index.js",
-    "dev": "tsx --env-file=.env --watch ./src/index.js",
-    "dev:pretty": "tsx --env-file=.env --watch ./src/index.js | pino-pretty -tc",
+    "ensure-signing-key": "[ -e 'sig/enclave-key.pem' ] && echo 'using existing signing key' || (mkdir -p sig && openssl genrsa -3 -out sig/enclave-key.pem 3072 && echo 'generated new signing key')",
+    "start": "npm run ensure-signing-key && tsx --env-file=.env ./src/index.js",
+    "dev": "npm run ensure-signing-key && tsx --env-file=.env --watch ./src/index.js",
+    "dev:pretty": "npm run ensure-signing-key && tsx --env-file=.env --watch ./src/index.js | pino-pretty -tc",
     "check-format": "prettier --check .",
     "check-types": "tsc --project tsconfig.json",
     "format": "prettier --write .",

--- a/api/src/sconify/deprecated_sconify.service.ts
+++ b/api/src/sconify/deprecated_sconify.service.ts
@@ -131,7 +131,6 @@ export async function deprecated_sconify({
     sconifiedImageId = await sconifyImage({
       fromImage: dockerImageToSconify,
       sconifyVersion,
-      entrypoint: appEntrypoint,
       binary: configTemplate.binary,
     });
     logger.info({ sconifiedImageId }, 'Sconified successfully');

--- a/api/src/sconify/sconifyBuild.handler.ts
+++ b/api/src/sconify/sconifyBuild.handler.ts
@@ -61,6 +61,9 @@ async function handleSconifyRequest(requestObj: object) {
   if (sconeVersion === 'v5') {
     logger.warn('Deprecated feature hit: sconeVersion === "v5"');
   }
+  if (sconeProd === false) {
+    logger.warn('Deprecated feature hit: sconeProd === false');
+  }
 
   const { dockerImage, dockerImageDigest, fingerprint, entrypoint } =
     await sconify({

--- a/api/src/sconify/sconifyBuild.handler.ts
+++ b/api/src/sconify/sconifyBuild.handler.ts
@@ -29,6 +29,7 @@ const bodySchema = z.object({
     .enum(Object.keys(TEMPLATE_CONFIG) as [TemplateName])
     .default('JavaScript'),
   sconeVersion: z.enum(['v5', 'v5.9']).default('v5'),
+  sconeProd: z.boolean().default(false),
 });
 
 async function handleSconifyRequest(requestObj: object) {
@@ -37,6 +38,7 @@ async function handleSconifyRequest(requestObj: object) {
   let dockerhubPushToken: string;
   let sconeVersion: SconeVersion;
   let template: TemplateName;
+  let sconeProd: boolean;
   try {
     ({
       yourWalletPublicAddress,
@@ -44,6 +46,7 @@ async function handleSconifyRequest(requestObj: object) {
       dockerhubPushToken,
       sconeVersion,
       template,
+      sconeProd,
     } = bodySchema.parse(requestObj));
   } catch (error) {
     throw fromError(error, {
@@ -66,6 +69,7 @@ async function handleSconifyRequest(requestObj: object) {
       userWalletPublicAddress: yourWalletPublicAddress,
       sconeVersion,
       templateLanguage: template,
+      sconeProd,
     });
   return {
     dockerImage,

--- a/api/src/sconify/sconifyBuild.service.ts
+++ b/api/src/sconify/sconifyBuild.service.ts
@@ -23,6 +23,7 @@ export async function sconify({
   pushToken,
   sconeVersion,
   templateLanguage,
+  sconeProd = false,
 }: {
   /**
    * Examples of valid dockerImageToSconify:
@@ -39,6 +40,7 @@ export async function sconify({
   pushToken: string;
   templateLanguage: TemplateName;
   sconeVersion: SconeVersion;
+  sconeProd?: boolean;
 }): Promise<{
   dockerImage: string;
   dockerImageDigest: string;
@@ -58,6 +60,7 @@ export async function sconify({
       templateLanguage,
       userWalletPublicAddress,
       wsEnabled,
+      sconeProd,
     },
     'New sconify request'
   );
@@ -142,6 +145,7 @@ export async function sconify({
       sconifyVersion,
       entrypoint: appEntrypoint,
       binary: configTemplate.binary,
+      prod: sconeProd,
     });
     logger.info({ sconifiedImageId }, 'Sconified successfully');
   } finally {
@@ -168,7 +172,7 @@ export async function sconify({
 
   const imageRepo = `${dockerUserName}/${imageName}`;
   const sconifiedImageShortId = sconifiedImageId.substring(7, 7 + 12); // extract 12 first chars after the leading "sha256:"
-  const sconifiedImageTag = `${imageTag}-tee-scone-${sconifyVersion}-debug-${sconifiedImageShortId}`; // add digest in tag to avoid replacing previous build
+  const sconifiedImageTag = `${imageTag}-tee-scone-${sconifyVersion}-${sconeProd ? 'prod' : 'debug'}-${sconifiedImageShortId}`; // add digest in tag to avoid replacing previous build
   const sconifiedImage = `${imageRepo}:${sconifiedImageTag}`;
 
   let pushed;

--- a/api/src/sconify/sconifyBuild.service.ts
+++ b/api/src/sconify/sconifyBuild.service.ts
@@ -143,7 +143,6 @@ export async function sconify({
     sconifiedImageId = await sconifyImage({
       fromImage: dockerImageToSconify,
       sconifyVersion,
-      entrypoint: appEntrypoint,
       binary: configTemplate.binary,
       prod: sconeProd,
     });

--- a/api/src/singleFunction/sconifyImage.ts
+++ b/api/src/singleFunction/sconifyImage.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import { access, constants } from 'node:fs/promises';
 import Docker from 'dockerode';
 import { SCONIFY_IMAGE_NAME } from '../constants/constants.js';
 import { logger } from '../utils/logger.js';
@@ -8,6 +9,8 @@ import { pullSconeImage } from './pullSconeImage.js';
 import { removeContainer } from './removeContainer.js';
 
 const docker = new Docker();
+
+const ENCLAVE_KEY_PATH = join(process.cwd(), 'sig/enclave-key.pem');
 
 /**
  * Sconifies an iapp docker image
@@ -44,6 +47,19 @@ export async function sconifyImage({
   logger.info({ sconifierImage }, 'Pulling sconifier image...');
   await pullSconeImage(sconifierImage);
 
+  if (prod) {
+    // check signing key can be read on host
+    try {
+      await access(ENCLAVE_KEY_PATH, constants.R_OK);
+    } catch (error) {
+      logger.error(
+        { error, path: ENCLAVE_KEY_PATH },
+        'Cannot read enclave key from host'
+      );
+      throw new Error('Cannot read enclave key from host');
+    }
+  }
+
   const toImage = `${fromImage}-tmp-sconified-${Date.now()}`; // create an unique temporary identifier for the target image
   logger.info({ fromImage, toImage }, 'Sconifying...');
 
@@ -71,9 +87,7 @@ export async function sconifyImage({
       : sconifyBaseCmd,
     HostConfig: {
       Binds: prod
-        ? baseBinds.concat(
-            `${join(process.cwd(), 'sig/enclave-key.pem')}:/sig/enclave-key.pem`
-          ) // mount signing key
+        ? baseBinds.concat(`${ENCLAVE_KEY_PATH}:/sig/enclave-key.pem:ro`) // mount signing key
         : baseBinds,
     },
   });

--- a/api/src/singleFunction/sconifyImage.ts
+++ b/api/src/singleFunction/sconifyImage.ts
@@ -15,7 +15,6 @@ const docker = new Docker();
 export async function sconifyImage({
   fromImage,
   sconifyVersion,
-  entrypoint,
   binary,
   prod = false,
 }: {
@@ -28,10 +27,6 @@ export async function sconifyImage({
    */
   sconifyVersion: string;
   /**
-   * command to run the app (whitelisted)
-   */
-  entrypoint: string;
-  /**
    * whitelisted binary
    */
   binary: string;
@@ -41,7 +36,7 @@ export async function sconifyImage({
   prod?: boolean;
 }): Promise<string> {
   logger.info(
-    { fromImage, entrypoint },
+    { fromImage },
     `Running sconify command in ${prod ? 'prod' : 'debug'} mode...`
   );
   const sconifierImage = `${SCONIFY_IMAGE_NAME}:${sconifyVersion}`;
@@ -65,7 +60,6 @@ export async function sconifyImage({
     '--dlopen=1',
     '--no-color',
     '--verbose',
-    `--command=${entrypoint}`,
   ];
 
   const baseBinds = ['/var/run/docker.sock:/var/run/docker.sock'];

--- a/cli/src/cmd/debug.ts
+++ b/cli/src/cmd/debug.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers';
 import { askForWallet } from '../cli-helpers/askForWallet.js';
-import { getIExecDebug } from '../utils/iexec.js';
+import { getIExec } from '../utils/iexec.js';
 import { getSpinner } from '../cli-helpers/spinner.js';
 import * as color from '../cli-helpers/color.js';
 import { handleCliError } from '../cli-helpers/handleCliError.js';
@@ -26,7 +26,7 @@ export async function debug({
     const chainConfig = getChainConfig(chainName);
     spinner.info(`Using chain ${chainName}`);
     const signer = await askForWallet({ spinner });
-    const iexec = getIExecDebug({
+    const iexec = getIExec({
       ...chainConfig,
       signer,
     });

--- a/cli/src/cmd/deploy.ts
+++ b/cli/src/cmd/deploy.ts
@@ -15,7 +15,7 @@ import { handleCliError } from '../cli-helpers/handleCliError.js';
 import { getSpinner } from '../cli-helpers/spinner.js';
 import { askForAppSecret } from '../cli-helpers/askForAppSecret.js';
 import { askForWallet } from '../cli-helpers/askForWallet.js';
-import { getIExecDebug } from '../utils/iexec.js';
+import { getIExec } from '../utils/iexec.js';
 import { goToProjectRoot } from '../cli-helpers/goToProjectRoot.js';
 import * as color from '../cli-helpers/color.js';
 import { hintBox } from '../cli-helpers/box.js';
@@ -43,7 +43,7 @@ export async function deploy({ chain }: { chain?: string }) {
     if (useTdx) {
       iexec = getIExecTdx({ ...chainConfig, signer });
     } else {
-      iexec = getIExecDebug({ ...chainConfig, signer });
+      iexec = getIExec({ ...chainConfig, signer });
     }
 
     await ensureBalances({ spinner, iexec });

--- a/cli/src/cmd/run.ts
+++ b/cli/src/cmd/run.ts
@@ -11,7 +11,7 @@ import {
 import { addRunData } from '../utils/cacheExecutions.js';
 import { getSpinner, type Spinner } from '../cli-helpers/spinner.js';
 import { handleCliError } from '../cli-helpers/handleCliError.js';
-import { getIExecDebug } from '../utils/iexec.js';
+import { getIExec } from '../utils/iexec.js';
 import { extractZipToFolder } from '../utils/extractZipToFolder.js';
 import { askShowResult } from '../cli-helpers/askShowResult.js';
 import { goToProjectRoot } from '../cli-helpers/goToProjectRoot.js';
@@ -104,7 +104,7 @@ export async function runInDebug({
   if (useTdx) {
     iexec = getIExecTdx({ ...chainConfig, signer });
   } else {
-    iexec = getIExecDebug({
+    iexec = getIExec({
       ...chainConfig,
       signer,
     });
@@ -151,7 +151,7 @@ export async function runInDebug({
   // Workerpool Order
   spinner.start('Fetching workerpool order...');
   const workerpoolOrderbook = await iexec.orderbook.fetchWorkerpoolOrderbook({
-    workerpool: useTdx ? WORKERPOOL_TDX : chainConfig.workerpoolDebug,
+    workerpool: useTdx ? WORKERPOOL_TDX : chainConfig.workerpool,
     app: iAppAddress,
     dataset: protectedData || ethers.ZeroAddress,
     minTag: SCONE_TAG,

--- a/cli/src/config/config.ts
+++ b/cli/src/config/config.ts
@@ -70,10 +70,9 @@ export const WS_RECONNECTION_MAX_ATTEMPTS = Math.floor(
 
 type ChainConfig = {
   rpcHostUrl: string;
-  smsDebugUrl: string;
   ipfsGatewayUrl: string;
   iexecExplorerUrl: string;
-  workerpoolDebug: string;
+  workerpool: string;
 };
 
 export const DEFAULT_CHAIN = 'bellecour';
@@ -81,25 +80,22 @@ export const DEFAULT_CHAIN = 'bellecour';
 export const CHAINS_CONFIGURATIONS: Record<string, ChainConfig> = {
   bellecour: {
     rpcHostUrl: 'https://bellecour.iex.ec',
-    smsDebugUrl: 'https://sms.scone-debug.v8-bellecour.iex.ec',
     ipfsGatewayUrl: 'https://ipfs-gateway.v8-bellecour.iex.ec',
     iexecExplorerUrl: 'https://explorer.iex.ec/bellecour',
-    workerpoolDebug: 'debug-v8-learn.main.pools.iexec.eth',
+    workerpool: 'prod-v8-learn.main.pools.iexec.eth',
   },
   'arbitrum-mainnet': {
     rpcHostUrl: 'https://arb1.arbitrum.io/rpc',
-    smsDebugUrl: 'https://sms-debug.arbitrum-mainnet.iex.ec',
     ipfsGatewayUrl: 'https://ipfs-gateway.arbitrum-mainnet.iex.ec',
     iexecExplorerUrl: 'https://explorer.iex.ec/arbitrum-mainnet',
-    workerpoolDebug: '0xAaA90d37034fD1ea27D5eF2879f217fB6fD7F7Ca',
+    workerpool: '0x2c06263943180cc024daffeee15612db6e5fd248',
   },
   ...(useExperimentalNetworks && {
     'arbitrum-sepolia-testnet': {
       rpcHostUrl: 'https://sepolia-rollup.arbitrum.io/rpc',
-      smsDebugUrl: 'https://sms.arbitrum-sepolia-testnet.iex.ec',
       ipfsGatewayUrl: 'https://ipfs-gateway.arbitrum-sepolia-testnet.iex.ec',
       iexecExplorerUrl: 'https://explorer.iex.ec/arbitrum-sepolia-testnet',
-      workerpoolDebug: '0xB967057a21dc6A66A29721d96b8Aa7454B7c383F',
+      workerpool: '0xB967057a21dc6A66A29721d96b8Aa7454B7c383F',
     },
   }),
 };

--- a/cli/src/utils/iexec.ts
+++ b/cli/src/utils/iexec.ts
@@ -3,21 +3,18 @@ import { AbstractSigner } from 'ethers';
 import { IExec } from 'iexec';
 import { useExperimentalNetworks } from './featureFlags.js';
 
-export function getIExecDebug({
+export function getIExec({
   signer,
   rpcHostUrl,
-  smsDebugUrl,
 }: {
   signer: AbstractSigner;
   rpcHostUrl: string;
-  smsDebugUrl: string;
 }): IExec {
   return new IExec(
     {
       ethProvider: signer.connect(new JsonRpcProvider(rpcHostUrl)),
     },
     {
-      smsURL: smsDebugUrl,
       allowExperimentalNetworks: useExperimentalNetworks,
     }
   );

--- a/cli/src/utils/sconify.ts
+++ b/cli/src/utils/sconify.ts
@@ -125,6 +125,7 @@ export async function sconify({
               dockerhubPushToken: pushToken,
               yourWalletPublicAddress: walletAddress,
               sconeVersion: DEFAULT_SCONE_VERSION,
+              sconeProd: true,
             })
           );
         },


### PR DESCRIPTION
# migrate iapp from Scone debug to Scone prod

## changes

API:
- Added `sconeProd` boolean option to sconify in production (default `false` for backward compatibility)
- `start` script generates a new signing key in `sig/enclave-key.pem` if not found
- `--command` option is no longer passed to the scone CLI (according to Scone team, this was useless)

CLI:
> :warning: the API must be deployed before the CLI publication
- Switched stack to use scone prod (SMS, Workerpool)
- Updated API request with `sconeProd: true` to use sconification in prod mode

CI:
- signing key mounted from host (RO) for API deployment
- Added server configuration files check before deploying the API

## tests

deployed app with successful run on prod workerpool:

- bellecour: https://explorer.iex.ec/bellecour/app/0xf6f6b7e5a6208e77de88ed8a59e56ab5177c5a32
- arbitrum: https://explorer.iex.ec/arbitrum-mainnet/app/0x156333bc13c422633754b828a5f64ee2180fd342
- arbitrum-sepolia: https://explorer.iex.ec/arbitrum-sepolia-testnet/app/0x6b82d0171f42b793e30957334c5995fd7ed24e6b