### PR TITLE
fix: stop blocking iapp deploy when RLC balance is empty

### DIFF
--- a/cli/src/cli-helpers/ensureBalances.ts
+++ b/cli/src/cli-helpers/ensureBalances.ts
@@ -43,7 +43,7 @@ export async function ensureBalances({
     const helpers = [];
     if (missingNative) {
       const msg =
-        ' - Native asset balance required for blockchain transactions is ' +
+        ' - Native asset balance needed for transaction fees is ' +
         (wei.isZero() ? 'empty' : 'insufficient');
       const requirement = weiMin
         ? ` (requires ${utils.formatEth(weiMin as BN)} ether)`
@@ -52,7 +52,7 @@ export async function ensureBalances({
     }
     if (missingRlc) {
       const msg =
-        ' - RLC token balance required for iapp runs is ' +
+        ' - RLC token balance needed for iapp runs is ' +
         (totalRlc.isZero() ? 'empty' : 'insufficient') +
         (warnOnlyRlc ? promptHelper(' (warning only)') : '');
       const requirement = nRlcMin
@@ -62,7 +62,7 @@ export async function ensureBalances({
     }
 
     spinner.log(
-      warnBox(`Current chain requires ${chainId !== 134 ? 'native asset to pay transaction fees and ' : ''}RLC to pay iApp runs!
+      warnBox(`Operations on this chain require ${chainId !== 134 ? 'native assets for transaction fees and ' : ''}RLC for iApp runs!
  
 Your wallet balance is insufficient:
 ${helpers.join('\n')}

--- a/cli/src/cmd/deploy.ts
+++ b/cli/src/cmd/deploy.ts
@@ -46,7 +46,7 @@ export async function deploy({ chain }: { chain?: string }) {
       iexec = getIExec({ ...chainConfig, signer });
     }
 
-    await ensureBalances({ spinner, iexec });
+    await ensureBalances({ spinner, iexec, warnOnlyRlc: true });
 
     const dockerhubUsername = await askForDockerhubUsername({ spinner });
     const dockerhubAccessToken = await askForDockerhubAccessToken({ spinner });


### PR DESCRIPTION
RLC is not required for `iapp deploy` but is needed for `iapp run`.
This PR aimed to inform the user early that they will likely need RLC, without blocking them.

| case | behaviour |
|---|---|
| `iapp deploy` with empty wallet | Error <img width="880" height="316" alt="image" src="https://github.com/user-attachments/assets/49858675-2b64-476e-ba65-bf57f1cfdefd" />  |
| `iapp deploy` without RLC | Warn and continue <img width="880" height="575" alt="image" src="https://github.com/user-attachments/assets/b1352797-0a02-48da-831c-7ae25d36b95e" /> |
| `iapp run` without RLC | Error <img width="880" height="349" alt="image" src="https://github.com/user-attachments/assets/3b1dc30f-c36e-4641-9b94-505b9773280c" /> |