### PR TITLE
fix: resolve bad config file detection in wallet commands

### DIFF
--- a/cli/src/cmd/wallet-import.ts
+++ b/cli/src/cmd/wallet-import.ts
@@ -3,10 +3,12 @@ import { handleCliError } from '../cli-helpers/handleCliError.js';
 import { getSpinner } from '../cli-helpers/spinner.js';
 import * as color from '../cli-helpers/color.js';
 import { warnBeforeDeletePrivateKey } from '../cli-helpers/warnBeforeDeletePrivateKey.js';
+import { goToProjectRoot } from '../cli-helpers/goToProjectRoot.js';
 
 export async function walletImport() {
   const spinner = getSpinner();
   try {
+    await goToProjectRoot({ spinner });
     spinner.text = 'Importing wallet';
     await warnBeforeDeletePrivateKey({ spinner });
     const signer = await askForImportWallet({ spinner });

--- a/cli/src/cmd/wallet-select.ts
+++ b/cli/src/cmd/wallet-select.ts
@@ -4,10 +4,12 @@ import * as color from '../cli-helpers/color.js';
 import { KEYSTORE_PATH, listWalletsFromKeystore } from '../utils/keystore.js';
 import { warnBeforeDeletePrivateKey } from '../cli-helpers/warnBeforeDeletePrivateKey.js';
 import { readIAppConfig, writeIAppConfig } from '../utils/iAppConfigFile.js';
+import { goToProjectRoot } from '../cli-helpers/goToProjectRoot.js';
 
 export async function walletSelect() {
   const spinner = getSpinner();
   try {
+    await goToProjectRoot({ spinner });
     spinner.text = 'Selecting wallet';
     await warnBeforeDeletePrivateKey({ spinner });
     const config = await readIAppConfig();


### PR DESCRIPTION
## issue

`iapp wallet` command fails when invoked in a project sub directory

<img width="647" height="65" alt="image" src="https://github.com/user-attachments/assets/98c700ba-bf5f-4078-85fd-eeba579a34bc" />

## fix

use project root directory