### PR TITLE
fix: deprecate SGX SCONE and propose migration to TDX when possible

### DIFF
--- a/cli/src/cmd/deploy.ts
+++ b/cli/src/cmd/deploy.ts
@@ -59,12 +59,12 @@ export async function deploy({ chain }: { chain?: string }) {
             `SGX SCONE TEE framework is deprecated in favor of TDX and will be removed in future versions.
 Please consider redeploying your app with TDX instead.
         
-run ${color.command('EXPERIMENTAL_TDX_APP=1 iapp deploy')} to deploy your app with TDX now`
+run ${color.command('EXPERIMENTAL_TDX_APP=1 iapp deploy')} to deploy your app with TDX now.`
           )
         );
       } catch {
         spinner.warn(
-          'SGX SCONE TEE framework is deprecated and will be removed in a future version, please contact iExec support to know more about TDX and how to migrate your app'
+          'SGX SCONE TEE framework is deprecated and will be removed in a future version, please contact iExec support to know more about TDX and how to migrate your app.'
         );
       }
     }

--- a/cli/src/cmd/deploy.ts
+++ b/cli/src/cmd/deploy.ts
@@ -20,7 +20,7 @@ import { askForWallet } from '../cli-helpers/askForWallet.js';
 import { getIExec } from '../utils/iexec.js';
 import { goToProjectRoot } from '../cli-helpers/goToProjectRoot.js';
 import * as color from '../cli-helpers/color.js';
-import { hintBox } from '../cli-helpers/box.js';
+import { hintBox, warnBox } from '../cli-helpers/box.js';
 import { addDeploymentData } from '../utils/cacheExecutions.js';
 import { useTdx } from '../utils/featureFlags.js';
 import { ensureBalances } from '../cli-helpers/ensureBalances.js';
@@ -53,6 +53,24 @@ export async function deploy({ chain }: { chain?: string }) {
       throw new Error(
         `TEE framework ${teeFramework.toUpperCase()} is not supported on the selected chain`
       );
+    }
+
+    if (teeFramework === 'scone') {
+      try {
+        await iexec.config.resolveSmsURL({ teeFramework: 'tdx' });
+        spinner.log(
+          warnBox(
+            `SGX SCONE TEE framework is deprecated in favor of TDX and will be removed in future versions.
+Please consider redeploying your app with TDX instead.
+        
+run ${color.command('EXPERIMENTAL_TDX_APP=1 iapp deploy')} to deploy your app with TDX now`
+          )
+        );
+      } catch {
+        spinner.warn(
+          'SGX SCONE TEE framework is deprecated and will be removed in a future version, please contact iExec support to know more about TDX and how to migrate your app'
+        );
+      }
     }
 
     await ensureBalances({ spinner, iexec, warnOnlyRlc: true });

--- a/cli/src/cmd/run.ts
+++ b/cli/src/cmd/run.ts
@@ -47,7 +47,6 @@ export async function run({
       defaultChain,
       spinner,
     });
-    await warnBeforeTxFees({ spinner, chain: chainConfig.name });
 
     spinner.start('checking inputs...');
     // initialize iExec
@@ -110,6 +109,8 @@ run ${color.command('EXPERIMENTAL_TDX_APP=1 iapp deploy')} to redeploy your app 
         })
       );
     }
+
+    await warnBeforeTxFees({ spinner, chain: chainConfig.name });
 
     // Get wallet from privateKey
     const signer = await askForWallet({ spinner });

--- a/cli/src/cmd/run.ts
+++ b/cli/src/cmd/run.ts
@@ -19,6 +19,7 @@ import { ensureBalances } from '../cli-helpers/ensureBalances.js';
 import { askForAcknowledgment } from '../cli-helpers/askForAcknowledgment.js';
 import { warnBeforeTxFees } from '../cli-helpers/warnBeforeTxFees.js';
 import { resolveChainConfig } from '../cli-helpers/resolveChainConfig.js';
+import { warnBox } from '../cli-helpers/box.js';
 
 export async function run({
   iAppAddress,
@@ -68,6 +69,24 @@ export async function run({
       throw new Error(
         `TEE framework ${teeFramework.toUpperCase()} is not supported on the selected chain`
       );
+    }
+
+    if (teeFramework === 'scone') {
+      try {
+        await readOnlyIexec.config.resolveSmsURL({ teeFramework: 'tdx' });
+        spinner.log(
+          warnBox(
+            `SGX SCONE TEE framework is deprecated in favor of TDX and will be removed in future versions.
+Please consider redeploying your app with TDX instead.
+            
+run ${color.command('EXPERIMENTAL_TDX_APP=1 iapp deploy')} to redeploy your app with TDX`
+          )
+        );
+      } catch {
+        spinner.warn(
+          'SGX SCONE TEE framework is deprecated and will be removed in a future version, please contact iExec support to know more about TDX and how to migrate your app'
+        );
+      }
     }
 
     if (protectedData.length > 0) {

--- a/cli/src/cmd/run.ts
+++ b/cli/src/cmd/run.ts
@@ -78,12 +78,12 @@ export async function run({
             `SGX SCONE TEE framework is deprecated in favor of TDX and will be removed in future versions.
 Please consider redeploying your app with TDX instead.
             
-run ${color.command('EXPERIMENTAL_TDX_APP=1 iapp deploy')} to redeploy your app with TDX`
+run ${color.command('EXPERIMENTAL_TDX_APP=1 iapp deploy')} to redeploy your app with TDX.`
           )
         );
       } catch {
         spinner.warn(
-          'SGX SCONE TEE framework is deprecated and will be removed in a future version, please contact iExec support to know more about TDX and how to migrate your app'
+          'SGX SCONE TEE framework is deprecated and will be removed in a future version, please contact iExec support to know more about TDX and how to migrate your app.'
         );
       }
     }


### PR DESCRIPTION
# changes

| command | TDX supported | message |
| --- |--- |--- |
| `iapp deploy` | no (bellecour, arbitrum-mainnet) | <img width="1610" height="26" alt="image" src="https://github.com/user-attachments/assets/46aa0d3b-b392-4f75-8627-dced737491d6" /> |
| `iapp run` | no (bellecour, arbitrum-mainnet) | <img width="1610" height="26" alt="image" src="https://github.com/user-attachments/assets/d4738d51-91a1-49ba-8dd6-b1aa6c29c8ad" /> |
| `iapp deploy` | yes (arbitrum-sepolia-testnet) | <img width="1081" height="179" alt="image" src="https://github.com/user-attachments/assets/8b7290ad-ebd4-46b9-8f11-8245e8dabeec" /> |
| `iapp run` | yes (arbitrum-sepolia-testnet) | <img width="1081" height="179" alt="image" src="https://github.com/user-attachments/assets/7cbaef4c-a745-4640-8e87-67d027d9c20b" /> |